### PR TITLE
Assembly Stats Cleanup

### DIFF
--- a/files/sourceConfig/ncbi/gcaStats.json
+++ b/files/sourceConfig/ncbi/gcaStats.json
@@ -1,5 +1,4 @@
 {
-    "dataType": "enrich",
     "dbType": "location",
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/",
     "regexMatch": ".*assembly_stats\\.txt",

--- a/files/sourceConfig/ncbi/gcfStats.json
+++ b/files/sourceConfig/ncbi/gcfStats.json
@@ -1,5 +1,4 @@
 {
-    "dataType": "enrich",
     "dbType": "location",
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/",
     "regexMatch": ".*assembly_stats\\.txt",

--- a/src/sourceProcessing/ncbi/assemblyStats.py
+++ b/src/sourceProcessing/ncbi/assemblyStats.py
@@ -11,7 +11,11 @@ def combine(inputFolder: Path, outputFilePath: Path):
         with open(filePath, encoding="utf-8") as fp:
             data = fp.read()
 
-        info, table = data.rsplit("#", 1)
+        splitData = data.rsplit("#", 1)
+        if len(splitData) == 1: # No # found, error reading file
+            continue
+        
+        info, table = splitData
 
         # Info parsing
         infoData = {}


### PR DESCRIPTION
- Removed unused config property dataType from both stats source configs
- Processing assembly stats now skips malformed files