### PR TITLE
Fix stages

### DIFF
--- a/dataSources/anemone/db/config.json
+++ b/dataSources/anemone/db/config.json
@@ -4,7 +4,7 @@
     "auth": "auth.txt",
     "folderPrefix": true,
     "regexMatch": ".*\\.tsv\\.xz",
-    "globalProcessing": [
+    "perFileProcessing": [
         {
             "path": "lib/tools/extractor.py",
             "function": "Extractor.extract",

--- a/dataSources/bold/datapackage/config.json
+++ b/dataSources/bold/datapackage/config.json
@@ -10,7 +10,7 @@
             "{PATH, DOWNLOAD, datapackage.tar.gz}"
         ]
     },
-    "globalProcessing": [
+    "perFileProcessing": [
         {
             "path": "lib/tools/extractor.py",
             "function": "Extractor.extract",

--- a/dataSources/ena/variant/config.json
+++ b/dataSources/ena/variant/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_4/by_species/",
     "subDirectoryDepth": -1,
     "regexMatch": ".*\\.txt\\.gz",
-    "globalProcessing": [
+    "perFileProcessing": [
         {
             "path": "lib/tools/extractor.py",
             "function": "Extractor.extract",

--- a/dataSources/goat/db/config.json
+++ b/dataSources/goat/db/config.json
@@ -10,7 +10,7 @@
             "{PATH, DOWNLOAD, rawgoat.csv}"
         ]
     },
-    "globalProcessing": [
+    "perFileProcessing": [
         {
             "path": "sourceProcessing/goat/processing.py",
             "function": "clean",

--- a/dataSources/ncbi/biocollections/config.json
+++ b/dataSources/ncbi/biocollections/config.json
@@ -14,7 +14,7 @@
             "downloadedFile": "Unique_institution_codes.txt"
         } 
     ],
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/compileBiocollections.py",
             "function": "process",

--- a/dataSources/ncbi/gcaStats/config.json
+++ b/dataSources/ncbi/gcaStats/config.json
@@ -2,7 +2,7 @@
     "dbType": "location",
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/",
     "regexMatch": ".*assembly_stats\\.txt",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/assemblyStats.py",
             "function": "combine",

--- a/dataSources/ncbi/gcfStats/config.json
+++ b/dataSources/ncbi/gcfStats/config.json
@@ -2,7 +2,7 @@
     "dbType": "location",
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/",
     "regexMatch": ".*assembly_stats\\.txt",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/assemblyStats.py",
             "function": "combine",

--- a/dataSources/ncbi/nucBacteria/config.json
+++ b/dataSources/ncbi/nucBacteria/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbbct\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucConstructed/config.json
+++ b/dataSources/ncbi/nucConstructed/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbcon\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucEnvironmental/config.json
+++ b/dataSources/ncbi/nucEnvironmental/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbenv\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucExpressedSeq/config.json
+++ b/dataSources/ncbi/nucExpressedSeq/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbest\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucGenomeSurvey/config.json
+++ b/dataSources/ncbi/nucGenomeSurvey/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbgss\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucHighCDNA/config.json
+++ b/dataSources/ncbi/nucHighCDNA/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbhtc\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucHighGenomic/config.json
+++ b/dataSources/ncbi/nucHighGenomic/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbhtg\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucInvertebrate/config.json
+++ b/dataSources/ncbi/nucInvertebrate/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbinv\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucMammalian/config.json
+++ b/dataSources/ncbi/nucMammalian/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbmam\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucOtherVertibrate/config.json
+++ b/dataSources/ncbi/nucOtherVertibrate/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbvrt\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucPatent/config.json
+++ b/dataSources/ncbi/nucPatent/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbpat\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucPhage/config.json
+++ b/dataSources/ncbi/nucPhage/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbphg\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucPlant/config.json
+++ b/dataSources/ncbi/nucPlant/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbpln\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucPrimate/config.json
+++ b/dataSources/ncbi/nucPrimate/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbpri\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucRodent/config.json
+++ b/dataSources/ncbi/nucRodent/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbrod\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucSequenceTagged/config.json
+++ b/dataSources/ncbi/nucSequenceTagged/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbsts\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucSynthetic/config.json
+++ b/dataSources/ncbi/nucSynthetic/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbsyn\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucTranscriptome/config.json
+++ b/dataSources/ncbi/nucTranscriptome/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbtsa\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucViral/config.json
+++ b/dataSources/ncbi/nucViral/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbvrl\\d+\\.seq\\.gz",
-    "combineProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi/nucleotide.py",
             "function": "combine",

--- a/dataSources/ncbi/nucleotide/config.json
+++ b/dataSources/ncbi/nucleotide/config.json
@@ -3,7 +3,7 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gb[a-z]{3}\\d+\\.seq\\.gz",
-    "globalProcessing": [
+    "perFileProcessing": [
         {
             "path": "lib/tools/extractor.py",
             "function": "Extractor.extract",

--- a/dataSources/silva/metadata/config.json
+++ b/dataSources/silva/metadata/config.json
@@ -4,7 +4,7 @@
     "downloadLink": "https://www.arb-silva.de/",
     "regexMatch": ".*\\.gz$",
     "subDirectoryDepth": 0,
-    "globalProcessing": [
+    "perFileProcessing": [
         {
             "path": "lib/tools/extractor.py",
             "function": "Extractor.extract",

--- a/dataSources/vicMuseum/species/config.json
+++ b/dataSources/vicMuseum/species/config.json
@@ -12,7 +12,7 @@
             "{PATH, DOWNLOAD, species.csv}"
         ]
     },
-    "globalProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/vicMuseum/processing.py",
             "function": "expandTaxa",

--- a/src/lib/processing/stageFile.py
+++ b/src/lib/processing/stageFile.py
@@ -10,12 +10,11 @@ if TYPE_CHECKING:
     from lib.processing.stageScript import StageScript
 
 class StageFileStep(Enum):
-    RAW          = 0
-    INTERMEDIATE = 1
-    PROCESSED    = 2
-    COMBINED     = 3
-    PRE_DWC      = 4
-    DWC          = 5
+    DOWNLOADED   = 0
+    PROCESSED    = 1
+    PRE_DWC      = 2
+    DWC          = 3
+    INTERMEDIATE = 4
 
 class StageFile:
     def __init__(self, filePath: Path, fileProperties: dict, parentScript: StageScript, stage: StageFileStep):

--- a/src/lib/sourceObjs/argParseWrapper.py
+++ b/src/lib/sourceObjs/argParseWrapper.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import IO
 from lib.sourceManager import SourceManager
 from lib.sourceObjs.sourceDatabase import Database
 

--- a/src/lib/sourceObjs/sourceDatabase.py
+++ b/src/lib/sourceObjs/sourceDatabase.py
@@ -1,17 +1,17 @@
 import lib.config as cfg
 from pathlib import Path
-from enum import Enum, auto
+from enum import Enum
 from lib.sourceObjs.systemManager import SystemManager
 from lib.sourceObjs.timeManager import TimeManager
 from lib.processing.stageFile import StageFile, StageFileStep
 from lib.tools.crawler import Crawler
 
 class DBType(Enum):
-    UNKNOWN = auto()
-    SPECIFIC = auto()
-    LOCATION = auto()
-    SCRIPTURL = auto()
-    SCRIPTDATA = auto()
+    UNKNOWN    = -1
+    SPECIFIC   = 0
+    LOCATION   = 1
+    SCRIPTURL  = 2
+    SCRIPTDATA = 3
 
 class Database:
     def __init__(self, location: str, database: str, properties: dict = {}):
@@ -21,8 +21,8 @@ class Database:
 
         # Standard properties
         self.authFile = properties.pop("auth", "")
-        self.globalProcessing = properties.pop("globalProcessing", [])
-        self.combineProcessing = properties.pop("combineProcessing", [])
+        self.perFileProcessing = properties.pop("perFileProcessing", [])
+        self.finalProcessing = properties.pop("finalProcessing", [])
         self.dwcProperties = properties.pop("dwcProperties", {})
 
         self.locationDir = cfg.folders.datasources / location
@@ -30,7 +30,7 @@ class Database:
         self.systemManager = SystemManager(self.location, self.databaseDir, self.dwcProperties, self.authFile)
         self.timeManager = TimeManager(self.databaseDir)
 
-        self.postInit(properties)
+        self._postInit(properties)
         self.checkLeftovers(properties)
 
     def __str__(self):
@@ -39,14 +39,28 @@ class Database:
     def __repr__(self):
         return str(self)
 
-    def postInit(self, properties: dict) -> None:
-        raise NotImplementedError
-
-    def prepare(self) -> None:
+    def _postInit(self, properties: dict) -> None:
         raise NotImplementedError
     
+    def _prepare(self, buildProcessing: bool = True, **kwargs) -> None:
+        raise NotImplementedError
+    
+    def prepareStage(self, stage: StageFileStep) -> None:
+        buildProcessing = stage != StageFileStep.DOWNLOADED # Do not build processing if stage file step is only for downloaded
+        self._prepare(buildProcessing=buildProcessing)
+
+        if stage == StageFileStep.PROCESSED:
+            return
+        
+        self.systemManager.addFinalStage(self.finalProcessing)
+
+        if stage == StageFileStep.PRE_DWC:
+            return
+        
+        self.systemManager.prepareDwC()
+    
     def download(self, fileNumbers: list[int] = [], overwrite: int = 0) -> None:
-        self._create(StageFileStep.RAW, fileNumbers, overwrite)
+        self._create(StageFileStep.DOWNLOADED, fileNumbers, overwrite)
 
     def createPreDwC(self, fileNumbers: list[int] = [], overwrite: int = 0) -> None:
         self._create(StageFileStep.PRE_DWC, fileNumbers, overwrite)
@@ -99,14 +113,15 @@ class Database:
 
 class SpecificDB(Database):
 
-    def postInit(self, properties: dict) -> None:
+    def _postInit(self, properties: dict) -> None:
         self.dbType = DBType.SPECIFIC
         self.files = properties.pop("files", None)
 
         if self.files is None:
             raise Exception("No provided files for source") from AttributeError
 
-    def prepare(self) -> None:
+    def _prepare(self, buildProcessing: bool = True) -> None:
+        print("RUNNING PREPARE")
         for file in self.files:
             url = file.get("url", None)
             fileName = file.get("downloadedFile", None)
@@ -119,16 +134,11 @@ class SpecificDB(Database):
             if fileName is None:
                 raise Exception("No filename provided to download to") from AttributeError
             
-            self.systemManager.addDownloadURLStage(url, fileName, processingSteps, fileProperties)
-
-        if self.combineProcessing:
-            self.systemManager.addCombineStage(self.combineProcessing)
-        
-        self.systemManager.pushPreDwC()
+            self.systemManager.addDownloadURLStage(url, fileName, processingSteps, fileProperties, buildProcessing=buildProcessing)
 
 class LocationDB(Database):
 
-    def postInit(self, properties: dict) -> None:
+    def _postInit(self, properties: dict) -> None:
         self.dbType = DBType.LOCATION
         self.localFile = "files.txt"
 
@@ -144,7 +154,7 @@ class LocationDB(Database):
         
         self.crawler = Crawler(self.databaseDir, self.regexMatch, self.downloadLink, self.maxSubDirDepth, user=self.systemManager.user, password=self.systemManager.password)
 
-    def prepare(self, recrawl: bool = False) -> None:
+    def _prepare(self, buildProcessing: bool = True, recrawl: bool = False) -> None:
         localFilePath = self.databaseDir / self.localFile
 
         if not recrawl and localFilePath.exists():
@@ -162,12 +172,7 @@ class LocationDB(Database):
 
         for url in urls:
             fileName = self.getFileNameFromURL(url)
-            self.systemManager.addDownloadURLStage(url, fileName, self.globalProcessing, self.fileProperties)
-
-        if self.combineProcessing:
-            self.systemManager.addCombineStage(self.combineProcessing)
-
-        self.systemManager.pushPreDwC()
+            self.systemManager.addDownloadURLStage(url, fileName, self.perFileProcessing, self.fileProperties, buildProcessing=buildProcessing)
 
     def getFileNameFromURL(self, url: str) -> str:
         urlParts = url.split('/')
@@ -181,17 +186,12 @@ class LocationDB(Database):
 
 class ScriptDB(Database):
 
-    def postInit(self, properties: dict) -> None:
+    def _postInit(self, properties: dict) -> None:
         self.dbType = DBType.SCRIPTDATA
         self.script = properties.pop("script", None)
 
         if self.script is None:
             raise Exception("No script specified") from AttributeError
         
-    def prepare(self) -> None:
-        self.systemManager.addRetrieveScriptStage(self.script, self.globalProcessing)
-
-        if self.combineProcessing:
-            self.systemManager.addCombineStage(self.combineProcessing)
-
-        self.systemManager.pushPreDwC()
+    def prepare(self, buildProcessing: bool = True) -> None:
+        self.systemManager.addRetrieveScriptStage(self.script, self.perFileProcessing, buildProcessing=buildProcessing)

--- a/src/lib/sourceObjs/sourceDatabase.py
+++ b/src/lib/sourceObjs/sourceDatabase.py
@@ -46,7 +46,6 @@ class Database:
         raise NotImplementedError
     
     def download(self, fileNumbers: list[int] = [], overwrite: int = 0) -> None:
-        print(fileNumbers, overwrite)
         self._create(StageFileStep.RAW, fileNumbers, overwrite)
 
     def createPreDwC(self, fileNumbers: list[int] = [], overwrite: int = 0) -> None:

--- a/src/lib/sourceObjs/sourceLocation.py
+++ b/src/lib/sourceObjs/sourceLocation.py
@@ -36,5 +36,4 @@ class SourceLocation:
             databaseInfo = json.load(fp)
 
         db = self.createDB(database, databaseInfo)
-        db.prepare()
         return db

--- a/src/lib/sourceObjs/systemManager.py
+++ b/src/lib/sourceObjs/systemManager.py
@@ -3,6 +3,7 @@ from lib.processing.stageFile import StageFileStep, StageFile
 from lib.processing.stageScript import StageDownloadScript, StageScript, StageDWCConversion
 from lib.processing.parser import SelectorParser
 from lib.processing.dwcProcessor import DWCProcessor
+from copy import deepcopy
 import concurrent.futures
 
 class SystemManager:
@@ -49,7 +50,6 @@ class SystemManager:
                 else:
                     print(f"Invalid number provided: {number}")
 
-        print(files)
         if len(files) <= 10: # Skip threadpool if only 1 file being processed
             return any(file.create(stage, overwrite) for file in files) # Return if any files were created
 
@@ -108,7 +108,7 @@ class SystemManager:
         for idx, stage in enumerate(fileStages[:-1], start=1):
             nextStage = fileStages[idx]
             if self.stages[stage] and not self.stages[nextStage]: # If this stage has files and next doesn't
-                for stageFile in self.stages[stage].copy():
+                for stageFile in deepcopy(self.stages[stage]):
                     stageFile.updateStage(nextStage)
                     self.stages[nextStage].append(stageFile)
                     

--- a/src/lib/sourceObjs/systemManager.py
+++ b/src/lib/sourceObjs/systemManager.py
@@ -33,20 +33,20 @@ class SystemManager:
         self.parser = SelectorParser(self.rootDir, self.dataDir, self.downloadDir, self.processingDir, self.preConversionDir, self.dwcDir)
         self.dwcProcessor = DWCProcessor(self.location, self.dwcProperties, self.dwcDir)
 
-        self.stages: dict[StageFileStep, list[StageFile]] = {stage: [] for stage in StageFileStep}
+        self.stageFiles: dict[StageFileStep, list[StageFile]] = {stage: [] for stage in StageFileStep}
 
     def getFiles(self, stage: StageFileStep) -> list[StageFile]:
-        return self.stages[stage]
+        return self.stageFiles[stage]
     
     def create(self, stage: StageFileStep, fileNumbers: list[int] = [], overwrite: int = 0, maxWorkers: int = 100) -> bool:
         files: list[StageFile] = []
         
         if not fileNumbers: # Create all files:
-            files = self.stages[stage] # All stage files
+            files = self.stageFiles[stage] # All stage files
         else:
             for number in fileNumbers:
-                if number >= 0 and number <= len(self.stages[stage]):
-                    files.append(self.stages[stage][number])
+                if number >= 0 and number <= len(self.stageFiles[stage]):
+                    files.append(self.stageFiles[stage][number])
                 else:
                     print(f"Invalid number provided: {number}")
 
@@ -81,42 +81,32 @@ class SystemManager:
             stage = StageFileStep.INTERMEDIATE if idx < len(processingSteps) else finalStage
             inputs = [StageFile(filePath, properties, scriptStep, stage) for filePath, properties in scriptStep.getOutputs()]
 
-        self.stages[finalStage].extend(inputs)
+        self.stageFiles[finalStage].extend(inputs)
 
-    def addDownloadURLStage(self, url: str, fileName: str, processing: list[dict], fileProperties: dict = {}):
+    def addDownloadURLStage(self, url: str, fileName: str, processing: list[dict], fileProperties: dict = {}, buildProcessing: bool =True):
         downloadedFile = self.downloadDir / fileName # downloaded files go into download directory
         downloadScript = StageDownloadScript(url, downloadedFile, self.parser, self.user, self.password)
         
-        rawFile = StageFile(downloadedFile, fileProperties.copy(), downloadScript, StageFileStep.RAW)
-        self.stages[StageFileStep.RAW].append(rawFile)
+        rawFile = StageFile(downloadedFile, fileProperties.copy(), downloadScript, StageFileStep.DOWNLOADED)
+        self.stageFiles[StageFileStep.DOWNLOADED].append(rawFile)
 
-        self.buildProcessingChain(processing, [rawFile], StageFileStep.PROCESSED)
+        if buildProcessing:
+            self.buildProcessingChain(processing, [rawFile], StageFileStep.PROCESSED)
 
-    def addRetrieveScriptStage(self, script, processing):
+    def addRetrieveScriptStage(self, script: dict, processing: list[dict], buildProcessing: bool = True):
         scriptStep = StageScript(script, [], self.parser)
-        outputs = [StageFile(filePath, properties, scriptStep, StageFileStep.RAW) for filePath, properties in scriptStep.getOutputs()]
-        self.stages[StageFileStep.RAW].extend(outputs)
+        outputs = [StageFile(filePath, properties, scriptStep, StageFileStep.DOWNLOADED) for filePath, properties in scriptStep.getOutputs()]
+        self.stageFiles[StageFileStep.DOWNLOADED].extend(outputs)
 
-        self.buildProcessingChain(processing, outputs, StageFileStep.PROCESSED)
+        if not buildProcessing:
+            self.buildProcessingChain(processing, outputs, StageFileStep.PROCESSED)
     
-    def addCombineStage(self, processing):
-        self.buildProcessingChain(processing, self.stages[StageFileStep.PROCESSED], StageFileStep.COMBINED)
+    def addFinalStage(self, processing):
+        self.buildProcessingChain(processing, self.stageFiles[StageFileStep.PROCESSED], StageFileStep.PRE_DWC)
     
-    def pushPreDwC(self, verbose=False):
-        fileStages = (StageFileStep.RAW, StageFileStep.PROCESSED, StageFileStep.COMBINED, StageFileStep.PRE_DWC)
-        
-        for idx, stage in enumerate(fileStages[:-1], start=1):
-            nextStage = fileStages[idx]
-            if self.stages[stage] and not self.stages[nextStage]: # If this stage has files and next doesn't
-                for stageFile in deepcopy(self.stages[stage]):
-                    stageFile.updateStage(nextStage)
-                    self.stages[nextStage].append(stageFile)
-                    
-                if verbose:
-                    print(f"Pushed files {stage.name} --> {nextStage.name}")
-
-        for file in self.stages[StageFileStep.PRE_DWC]:
+    def prepareDwC(self):
+        for file in self.stageFiles[StageFileStep.PRE_DWC]:
             conversionScript = StageDWCConversion(file, self.dwcProcessor)
             dwcOutput = conversionScript.getOutput()
             convertedFile = StageFile(dwcOutput, {}, conversionScript, StageFileStep.DWC)
-            self.stages[StageFileStep.DWC].append(convertedFile)
+            self.stageFiles[StageFileStep.DWC].append(convertedFile)

--- a/src/tools/source/dataDownload.py
+++ b/src/tools/source/dataDownload.py
@@ -1,8 +1,10 @@
 from lib.sourceObjs.argParseWrapper import SourceArgParser
+from lib.processing.stageFile import StageFileStep
 
 if __name__ == '__main__':
     parser = SourceArgParser(description="Download source data")
 
     sources, selectedFiles, args = parser.parse_args()
     for source in sources:
+        source.prepareStage(StageFileStep.DOWNLOADED)
         source.download(selectedFiles, args.overwrite)

--- a/src/tools/source/dwcCreate.py
+++ b/src/tools/source/dwcCreate.py
@@ -1,8 +1,10 @@
 from lib.sourceObjs.argParseWrapper import SourceArgParser
+from lib.processing.stageFile import StageFileStep
 
 if __name__ == '__main__':
     parser = SourceArgParser(description="Convert preDWC file to DWC")
     
     sources, selectedFiles, args = parser.parse_args()
     for source in sources:
+        source.prepareStage(StageFileStep.DWC)
         source.createDwC(selectedFiles, args.overwrite)

--- a/src/tools/source/getFields.py
+++ b/src/tools/source/getFields.py
@@ -2,7 +2,7 @@ import pandas as pd
 import json
 import lib.dataframeFuncs as dff
 from lib.sourceObjs.argParseWrapper import SourceArgParser
-from lib.processing.stageFile import StageFile
+from lib.processing.stageFile import StageFile, StageFileStep
 from lib.tools.remapper import Remapper
 import random
 
@@ -74,6 +74,7 @@ if __name__ == '__main__':
         #     print(f"Output file {output} already exists, please run with overwrite flag (-o) to overwrite")
         #     continue
 
+        source.prepareStage(StageFileStep.PRE_DWC)
         stageFiles = source.getPreDWCFiles(selectedFiles)
         remapper = source.systemManager.dwcProcessor.remapper
 

--- a/src/tools/source/preDWCCreate.py
+++ b/src/tools/source/preDWCCreate.py
@@ -1,8 +1,10 @@
 from lib.sourceObjs.argParseWrapper import SourceArgParser
+from lib.processing.stageFile import StageFileStep
 
 if __name__ == '__main__':
     parser = SourceArgParser(description="Prepare for DwC conversion")
     
     sources, selectedFiles, args = parser.parse_args()
     for source in sources:
+        source.prepareStage(StageFileStep.PRE_DWC)
         source.createPreDwC(selectedFiles, args.overwrite)

--- a/src/tools/source/viewDwC.py
+++ b/src/tools/source/viewDwC.py
@@ -1,5 +1,5 @@
 from lib.sourceObjs.argParseWrapper import SourceArgParser
-import pandas as pd
+from lib.processing.stageFile import StageFileStep
 
 if __name__ == '__main__':
     parser = SourceArgParser(description="View portion of DWC file")
@@ -10,6 +10,7 @@ if __name__ == '__main__':
     
     sources, selectedFiles, args = parser.parse_args()
     for source in sources:
+        source.prepareStage(StageFileStep.DWC)
         dwcFiles = source.getDWCFiles(selectedFiles)
         for file in dwcFiles:
             if not file.filePath.exists():


### PR DESCRIPTION
- Added preparation of data sources only up to a certain point as required
- Removed combine stage
- Final processing now creates a preDwC file
- Renamed global processing to per file processing
- Renamed combined processing to final processing
- Updated source configs to use names perFileProcessing and finalProcessing
- Stages is now called stageFiles in systemManager to better describe what it contains
- DBTypes enums no longer use auto
- Changed copy to deepcopy for pushing files up to preDwC
- Cleaned up some old redundant print statements