### PR TITLE
Nucleotide parsing

### DIFF
--- a/dataSources/ncbi/nucBacteria/config.json
+++ b/dataSources/ncbi/nucBacteria/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbbct\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucBacteria.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucConstructed/config.json
+++ b/dataSources/ncbi/nucConstructed/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbcon\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucConstructed.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucEnvironmental/config.json
+++ b/dataSources/ncbi/nucEnvironmental/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbenv\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucEnvironmental.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucExpressedSeq/config.json
+++ b/dataSources/ncbi/nucExpressedSeq/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbest\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucExpressedSeq.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucGenomeSurvey/config.json
+++ b/dataSources/ncbi/nucGenomeSurvey/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbgss\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucGenomeSurvey.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucHighCDNA/config.json
+++ b/dataSources/ncbi/nucHighCDNA/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbhtc\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucHighCDNA.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucHighGenomic/config.json
+++ b/dataSources/ncbi/nucHighGenomic/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbhtg\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucHighGenomic.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucInvertebrate/config.json
+++ b/dataSources/ncbi/nucInvertebrate/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbinv\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucInvertebrate.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucMammalian/config.json
+++ b/dataSources/ncbi/nucMammalian/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbmam\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucMammalian.csv}"
             ],
             "outputs": [

--- a/dataSources/ncbi/nucOtherVertibrate/config.json
+++ b/dataSources/ncbi/nucOtherVertibrate/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbvrt\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucOtherVertibrate.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucPatent/config.json
+++ b/dataSources/ncbi/nucPatent/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbpat\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucPatent.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucPhage/config.json
+++ b/dataSources/ncbi/nucPhage/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbphg\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucPhage.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucPlant/config.json
+++ b/dataSources/ncbi/nucPlant/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbpln\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucPlant.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucPrimate/config.json
+++ b/dataSources/ncbi/nucPrimate/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbpri\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucPrimate.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucRodent/config.json
+++ b/dataSources/ncbi/nucRodent/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbrod\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucRodent.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucSequenceTagged/config.json
+++ b/dataSources/ncbi/nucSequenceTagged/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbsts\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucSequenceTagged.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucSynthetic/config.json
+++ b/dataSources/ncbi/nucSynthetic/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbsyn\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucSynthetic.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucTranscriptome/config.json
+++ b/dataSources/ncbi/nucTranscriptome/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbtsa\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucTranscriptome.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/dataSources/ncbi/nucViral/config.json
+++ b/dataSources/ncbi/nucViral/config.json
@@ -3,25 +3,12 @@
     "dataLocation": "https://ftp.ncbi.nlm.nih.gov/genbank/",
     "subDirectoryDepth": 0,
     "regexMatch": "gbvrl\\d+\\.seq\\.gz",
-    "perFileProcessing": [
+    "finalProcessing": [
         {
             "path": "sourceProcessing/ncbi.py",
             "function": "parseNucleotide",
             "args": [
-                "{INPUT, 0, FILEPATH}",
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ],
-            "outputs": [
-                "{INPUTPATH, PROCESSING, 0, FILEPATH_STEM_STEM, .parquet}"
-            ]
-        }
-    ],
-    "finalProcessing": [
-        {
-            "path": "sourceProcessing/ncbi.py",
-            "function": "compileNucleotide",
-            "args": [
-                "{PATH, PROCESSING}",
+                "{PATH, DOWNLOAD}",
                 "{PATH, PREDWC, nucViral.csv}"
             ],
             "outputs": [
@@ -30,6 +17,7 @@
         }
     ],
     "dwcProperties": {
-        "mapID": 1182330400
+        "mapID": 1182330400,
+        "chunkSize": 512
     }
 }

--- a/src/lib/processing/stageFile.py
+++ b/src/lib/processing/stageFile.py
@@ -41,11 +41,11 @@ class StageFile:
     def updateStage(self, stage: StageFileStep) -> None:
         self.stage = stage
     
-    def loadDataFrame(self) -> pd.DataFrame:
-        return pd.read_csv(self.filePath, sep=self.separator, header=self.firstRow, encoding=self.encoding)
+    def loadDataFrame(self, offset: int = 0, rows: int = None) -> pd.DataFrame:
+        return pd.read_csv(self.filePath, sep=self.separator, header=self.firstRow + offset, encoding=self.encoding, nrows=rows)
     
-    def loadDataFrameIterator(self, chunkSize: int = 1024) -> Iterator[pd.DataFrame]:
-        return cmn.chunkGenerator(self.filePath, chunkSize, self.separator, self.firstRow, self.encoding)
+    def loadDataFrameIterator(self, chunkSize: int = 1024, offset: int = 0, rows: int = -1) -> Iterator[pd.DataFrame]:
+        return cmn.chunkGenerator(self.filePath, chunkSize, self.separator, self.firstRow + offset, self.encoding, nrows=rows)
 
     def getColumns(self) -> list[str]:
         return cmn.getColumns(self.filePath, self.separator, self.firstRow)

--- a/src/lib/processing/stageFile.py
+++ b/src/lib/processing/stageFile.py
@@ -44,7 +44,7 @@ class StageFile:
     def loadDataFrame(self) -> pd.DataFrame:
         return pd.read_csv(self.filePath, sep=self.separator, header=self.firstRow, encoding=self.encoding)
     
-    def loadDataFrameIterator(self, chunkSize: int = 1024 * 1024) ->  Iterator[pd.DataFrame]:
+    def loadDataFrameIterator(self, chunkSize: int = 1024) -> Iterator[pd.DataFrame]:
         return cmn.chunkGenerator(self.filePath, chunkSize, self.separator, self.firstRow, self.encoding)
 
     def getColumns(self) -> list[str]:

--- a/src/sourceProcessing/ncbi.py
+++ b/src/sourceProcessing/ncbi.py
@@ -4,7 +4,7 @@ import lib.dataframeFuncs as dff
 from pathlib import Path
 from lib.tools.bigFileWriter import BigFileWriter
 import concurrent.futures
-from sourceProcessing.ncbiFlatfileParser import FlatFileParser
+import sourceProcessing.ncbiFlatfileParser as ffp
 from lib.tools.zipping import RepeatExtractor
 from io import StringIO
 import json
@@ -114,7 +114,6 @@ def compileAssemblyStats(inputFolder: Path, outputFilePath: Path) -> None:
 
 def parseNucleotide(filePath: Path, outputFilePath: Path, verbose: bool = True) -> None:
     extractor = RepeatExtractor(outputFilePath.parent)
-    flatfileParser = FlatFileParser()
 
     records = []
     if verbose:
@@ -129,8 +128,7 @@ def parseNucleotide(filePath: Path, outputFilePath: Path, verbose: bool = True) 
     if verbose:
         print(f"Parsing file {extractedFile}")
 
-    records = flatfileParser.parse(extractedFile, verbose)
-    df = pd.DataFrame.from_records(records)
+    df = ffp.parseFlatfile(extractedFile, verbose)
     df.to_parquet(outputFilePath, index=False)
 
     extractedFile.unlink()

--- a/src/sourceProcessing/ncbi.py
+++ b/src/sourceProcessing/ncbi.py
@@ -115,25 +115,24 @@ def compileAssemblyStats(inputFolder: Path, outputFilePath: Path) -> None:
 def parseNucleotide(filePath: Path, outputFilePath: Path, verbose: bool = True) -> None:
     extractor = RepeatExtractor(outputFilePath.parent)
 
-    records = []
-    if verbose:
-        print(f"Extracting file {filePath}")
+    for idx, file in enumerate(rawFilesPath.iterdir(), start=1):
+        if verbose:
+            print(f"Extracting file {file.name}")
+        else:
+            print(f"Processing file: {idx}", end="\r")
     
     extractedFile = extractor.extract(filePath)
 
-    if extractedFile is None:
-        print("Failed to extract file, skipping")
-        return
+        if extractedFile is None:
+            print(f"Failed to extract file {file.name}, skipping")
+            continue
 
-    if verbose:
-        print(f"Parsing file {extractedFile}")
+        if verbose:
+            print(f"Parsing file {extractedFile}")
 
-    df = ffp.parseFlatfile(extractedFile, verbose)
-    df.to_parquet(outputFilePath, index=False)
+        df = ffp.parseFlatfile(extractedFile, verbose)
+        writer.writeDF(df)
 
-    extractedFile.unlink()
+        extractedFile.unlink()
 
-def compileNucleotide(folderPath: Path, outputFilePath: Path) -> None:
-    writer = BigFileWriter(outputFilePath, "seqChunks", "chunk")
-    writer.populateFromFolder(folderPath)
-    writer.oneFile(False)
+    writer.oneFile()

--- a/src/sourceProcessing/ncbiFlatfileParser.py
+++ b/src/sourceProcessing/ncbiFlatfileParser.py
@@ -182,7 +182,7 @@ def _parseReferences(data: str) -> dict[str, str]:
 
         reference[sectionName.lower()] = _flattenBlock(sectionData)
 
-    return {"referenes": reference}
+    return {"references": reference}
 
 def _parseFeatures(data: str) -> dict[str, str]:
     featureBlocks = _getSections(data, 5)

--- a/src/sourceProcessing/ncbiFlatfileParser.py
+++ b/src/sourceProcessing/ncbiFlatfileParser.py
@@ -128,7 +128,7 @@ def _parseEntry(entryBlock: str) -> dict:
             pass
 
     # Stringify columns so they can be saved as parqet/csv
-    stringColumns = ["authors", "bases"]
+    stringColumns = ["authors", "bases", "references"]
     for column in stringColumns:
         entryData[column] = str(entryData[column])
 
@@ -167,7 +167,7 @@ def _parseKeywords(data: str) -> dict[str, str]:
 def _parseSource(data: str) -> dict[str, str]: 
     source, leftover = _getSections(data, 2)
     organism, higherClassification = leftover.split("\n", 1)
-    return {"source": source.strip(), "organism": organism.split(" ", 1)[1].strip(), "higher_classification": _flattenBlock(higherClassification)}
+    return {"source": source.strip(), "organism": organism.strip().split(" ", 1)[1].strip(), "higher_classification": _flattenBlock(higherClassification)}
 
 def _parseReference(data: str, extract: dict) -> tuple[dict[str, str], dict[str, str | list]]:
     reference = {}

--- a/src/sourceProcessing/ncbiFlatfileParser.py
+++ b/src/sourceProcessing/ncbiFlatfileParser.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from enum import Enum
+import pandas as pd
 
 class Section(Enum):
     INFO = "INFO"
@@ -8,227 +9,244 @@ class Section(Enum):
     FEATURES = "FEATURES"
     ORIGIN = "ORIGIN"
 
-class FlatFileParser:
-    def __init__(self):
-        self.seqBaseURL = "https://ftp.ncbi.nlm.nih.gov/genbank/"
-        self.genbankBaseURL = "https://www.ncbi.nlm.nih.gov/nuccore/"
-        self.fastaSuffix = "?report=fasta&format=text"
+_seqBaseURL = "https://ftp.ncbi.nlm.nih.gov/genbank/"
+_genbankBaseURL = "https://www.ncbi.nlm.nih.gov/nuccore/"
+_fastaSuffix = "?report=fasta&format=text"
 
-    def parse(self, filePath: Path, verbose: bool = False) -> list[dict]:
-        with open(filePath) as fp:
-            try:
-                data = fp.read()
-            except UnicodeDecodeError:
-                print(f"Failed to read file: {filePath}")
-                return []
+def parseFlatfile(filePath: Path, verbose: bool = False) -> pd.DataFrame:
+    with open(filePath) as fp:
+        try:
+            data = fp.read()
+        except UnicodeDecodeError:
+            print(f"Failed to read file: {filePath}")
+            return []
 
-        # Cut off header of file
-        firstLocusPos = data.find("LOCUS")
-        header = data[:firstLocusPos]
-        data = data[firstLocusPos:]
+    # Cut off header of file
+    firstLocusPos = data.find("LOCUS")
+    header = data[:firstLocusPos]
+    data = data[firstLocusPos:]
 
-        records = []
-        for idx, entry in enumerate(data.split("//\n")[:-1], start=1): # Split into separate loci, exclude empty entry after last
-            if verbose:
-                print(f"Parsing entry: {idx}", end="\r")
-
-            entryData = self.parseEntry(entry)
-
-            # Attach seq file path and fasta file
-            # output["seq_file"] = f"{self.seqBaseURL}{filePath.name}.gz"
-            version = entryData.get("version", "")
-            if version:
-                entryData["genbank_url"] = f"{self.genbankBaseURL}{version}"
-                entryData["fasta_url"] = f"{self.genbankBaseURL}{version}{self.fastaSuffix}"
-
-            # Add specimen field
-            for value in (entryData.get("specimen_voucher", None), entryData.get("isolate", None), f"NCBI_{entryData['accession']}_specimen"):
-                if value is not None:
-                    entryData["specimen"] = value
-                    break
-
-            records.append(entryData)
-
+    records = []
+    for idx, entry in enumerate(data.split("//\n")[:-1], start=1): # Split into separate loci, exclude empty entry after last
         if verbose:
-            print()
+            print(f"Parsing entry: {idx}", end="\r")
 
-        return records
-    
-    def parseEntry(self, entryBlock: str) -> dict:
-        sections = self.getSections(entryBlock, allowDigits=False)
+        entryData = _parseEntry(entry)
 
-        entryData = {}
-        for section in sections:
-            heading, data = section.split(" ", 1)
-            # headings = ["LOCUS", "DEFINITION", "ACCESSION", "VERSION", "DBLINK", "KEYWORDS", "SOURCE", "ORGANISM"]
+        # Attach seq file path and fasta file
+        entryData["seq_file"] = f"{_seqBaseURL}{filePath.name}.gz"
+        version = entryData.get("version", "")
+        if version:
+            entryData["genbank_url"] = f"{_genbankBaseURL}{version}"
+            entryData["fasta_url"] = f"{_genbankBaseURL}{version}{_fastaSuffix}"
 
-            if heading == "LOCUS":
-                parameters = ["locus", "basepairs", "", "type", "shape", "seq_type", "date"]
-                entryData |= {param: value.strip() for param, value in zip(parameters, data.split()) if param}
-
-            elif heading in ("DEFINITION", "ACCESSION", "VERSION", "COMMENT"):
-                entryData[heading.lower()] = self.flattenBlock(data)
-
-            elif heading == "DBLINK":
-                dbs = {}
-                key = "unknown_db"
-
-                for line in data.split("\n"):
-                    if not line.strip():
-                        continue
-
-                    if ":" in line: # Line has a new key in it
-                        key, line = line.split(":")
-                        key = key.strip().lower()
-                        dbs[key] = []
-
-                    if key == "unknown_db": # Found a line before a db name
-                        dbs[key] = [] # Create a list for values with no db name
-                        
-                    dbs[key].extend([element.strip() for element in line.split(",")])
-
-                entryData |= dbs
-
-            elif heading == "KEYWORDS":
-                if data.strip() == ".":
-                    entryData["keywords"] = ""
-                else:
-                    entryData["keywords"] = self.flattenBlock(data)
-
-            elif heading == "SOURCE":
-                source, leftover = self.getSections(data, 2)
-                organism, higherClassification = leftover.split("\n", 1)
-
-                entryData["source"] = source.strip()
-                entryData["organism"] = organism.split(" ", 1)[1].strip()
-                entryData["higher_classification"] = self.flattenBlock(higherClassification)
-
-            elif heading == "REFERENCE":
-                reference = {}
-                refInfo = self.getSections(data, 2)
-                basesInfo = refInfo.pop(0)
-                basesInfo = basesInfo.strip(" \n").split(" ", 1)
-
-                if len(basesInfo) == 1: # Only reference number
-                    reference["bases"] = []
-                elif "bases" not in basesInfo[1]: # Bases not specified
-                    reference["bases"] = []
-                else:
-                    baseRanges = basesInfo[1].strip().lstrip("(bases").rstrip(")")
-                    bases = []
-                    for baseRange in baseRanges.split(";"):
-                        if not baseRange:
-                            continue
-
-                        try:
-                            basesFrom, basesTo = baseRange.split("to")
-                            bases.append(f"({basesFrom.strip()}) to {basesTo.strip()}")
-                        except:
-                            print(f"{data}, ERROR: {baseRange}")
-
-                    reference["bases"] = bases
-
-                for section in refInfo:
-                    sectionName, sectionData = section.strip().split(" ", 1)
-                    if sectionName == "JOURNAL":
-                        if "PUBMED" in sectionData:
-                            sectionData, pubmed = sectionData.split("PUBMED")
-                            reference["journal"] = self.flattenBlock(sectionData)
-                            reference["pubmed"] = pubmed.strip()
-
-                    reference[sectionName.lower()] = self.flattenBlock(sectionData)
-
-                if "references" not in entryData:
-                    entryData["references"] = []
-
-                entryData["references"].append(reference)
-
-            elif heading == "FEATURES":
-                featureBlocks = self.getSections(data, 5)
-                genes = {}
-                otherProperties = {}
-
-                for block in featureBlocks[1:]:
-                    sectionHeader, sectionData = block.lstrip().split(" ", 1)
-
-                    propertyList = self.flattenBlock(sectionData, "//").split("///")
-                    properties = {"bp_range": propertyList[0]}
-                    for property in propertyList[1:]: # base pair range is first property in list
-                        splitProperty = property.split("=")
-                        if len(splitProperty) == 2:
-                            key, value = splitProperty
-                        else:
-                            key = splitProperty[0]
-                            value = key
-
-                        properties[key] = value.strip('"')
-
-                    if sectionHeader == "source":
-                        value = properties.pop("organism", None)
-                        if value is not None:
-                            properties["features_organism"] = value
-
-                        entryData |= properties
-
-                    else:
-                        gene = properties.get("gene", None)
-                        if gene is not None:  # If section is associated with a gene
-                            properties.pop("gene")
-                            if gene not in genes:
-                                genes[gene] = {}
-
-                            if sectionHeader not in genes[gene]:
-                                genes[gene][sectionHeader] = []
-
-                            genes[gene][sectionHeader].append(properties)
-
-                        else: # Not associated with a gene
-                            if sectionHeader not in otherProperties:
-                                otherProperties[sectionHeader] = []
-
-                            otherProperties[sectionHeader].append(properties)
-                
-                # Only write genes and other properties if exists
-                if genes:
-                    entryData["genes"] = genes
-
-                if otherProperties:
-                    entryData["other_properties"] = otherProperties
-
-            elif heading == "ORIGIN":
-                pass # Skip adding of origin to output
-
-            else:
-                print(f"Unhandled heading: {heading}")
-
-        return entryData
-
-    def getSections(self, textBlock: str, whitespace: int = 0, allowDigits=True) -> list[str]:
-        sections = []
-        sectionStart = 0
-        searchPos = 0
-        textBlock = textBlock.rstrip("\n") # Make sure block doesn't end with newlines
-
-        while True:
-            nextNewlinePos = textBlock.find("\n", searchPos)
-            nextPlus1 = nextNewlinePos + 1
-
-            if nextNewlinePos < 0: # No next new line
-                sections.append(textBlock[sectionStart:])
+        # Add specimen field
+        for value in (entryData.get("specimen_voucher", None), entryData.get("isolate", None), f"NCBI_{entryData['accession']}_specimen"):
+            if value is not None:
+                entryData["specimen"] = value
                 break
 
-            if len(textBlock[nextPlus1:nextPlus1+whitespace+1].strip()) == 0: # No header on next line
-                searchPos = nextPlus1
-                continue
+        records.append(entryData)
 
-            if not allowDigits and textBlock[nextPlus1+whitespace+1].isdigit(): # Check for digit leading next header
-                searchPos = nextPlus1
-                continue
+    if verbose:
+        print()
 
-            sections.append(textBlock[sectionStart:nextNewlinePos])
-            sectionStart = searchPos = nextPlus1
-
-        return sections
+    return pd.DataFrame.from_records(records)
     
-    def flattenBlock(self, textBlock: str, joiner: str = " ") -> str:
-        return joiner.join(line.strip() for line in textBlock.split("\n") if line)
+def _parseEntry(entryBlock: str) -> dict:
+    sections = _getSections(entryBlock, allowDigits=False)
+
+    subParsers = {
+        "LOCUS": _parseLocus,
+        "DEFINITION": _parseText,
+        "ACCESSION": _parseText,
+        "VERSION": _parseText,
+        "COMMENT": _parseText,
+        "DBLINK": _parseDBs,
+        "KEYWORDS": _parseKeywords,
+        "SOURCE": _parseSource,
+        "REFERENCE": _parseReferences,
+        "FEATURES": _parseFeatures,
+        "ORIGIN": _parseOrigin,
+        "CONTIG": _parseOrigin
+    }
+
+    entryData = {}
+    for section in sections:
+        heading, data = section.split(" ", 1)
+        # headings = ["LOCUS", "DEFINITION", "ACCESSION", "VERSION", "DBLINK", "KEYWORDS", "SOURCE", "ORGANISM"]
+        
+        subParser = subParsers.get(heading, None)
+        if subParser is None:
+            print(f"Unhandled heading: {heading}")
+            continue
+
+        subParser(heading, data, entryData)
+    
+    return entryData
+
+def _parseLocus(heading: str, data: str, entryData: dict) -> None:
+        parameters = ["locus", "basepairs", "", "type", "shape", "seq_type", "date"]
+        entryData |= {param: value.strip() for param, value in zip(parameters, data.split()) if param}
+
+def _parseText(heading: str, data: str, entryData: dict) -> None:        
+    entryData[heading.lower()] = _flattenBlock(data)
+
+def _parseDBs(heading: str, data: str, entryData: dict) -> None:
+    dbs = {}
+    key = "unknown_db"
+
+    for line in data.split("\n"):
+        if not line.strip():
+            continue
+
+        if ":" in line: # Line has a new key in it
+            key, line = line.split(":")
+            key = key.strip().lower()
+            dbs[key] = []
+
+        if key == "unknown_db": # Found a line before a db name
+            dbs[key] = [] # Create a list for values with no db name
+            
+        dbs[key].extend([element.strip() for element in line.split(",")])
+
+    entryData |= dbs
+
+def _parseKeywords(heading: str, data: str, entryData: dict) -> None:
+    if data.strip() == ".":
+        entryData["keywords"] = ""
+    else:
+        entryData["keywords"] = _flattenBlock(data)
+
+def _parseSource(heqading: str, data: str, entryData: dict) -> None: 
+    source, leftover = _getSections(data, 2)
+    organism, higherClassification = leftover.split("\n", 1)
+
+    entryData["source"] = source.strip()
+    entryData["organism"] = organism.split(" ", 1)[1].strip()
+    entryData["higher_classification"] = _flattenBlock(higherClassification)
+
+def _parseReferences(heading: str, data: str, entryData: dict) -> None:
+    reference = {}
+    refInfo = _getSections(data, 2)
+    basesInfo = refInfo.pop(0)
+    basesInfo = basesInfo.strip(" \n").split(" ", 1)
+
+    if len(basesInfo) == 1: # Only reference number
+        reference["bases"] = []
+    elif "bases" not in basesInfo[1]: # Bases not specified
+        reference["bases"] = []
+    else:
+        baseRanges = basesInfo[1].strip().lstrip("(bases").rstrip(")")
+        bases = []
+        for baseRange in baseRanges.split(";"):
+            if not baseRange:
+                continue
+
+            try:
+                basesFrom, basesTo = baseRange.split("to")
+                bases.append(f"({basesFrom.strip()}) to {basesTo.strip()}")
+            except:
+                print(f"{data}, ERROR: {baseRange}")
+
+        reference["bases"] = bases
+
+    for section in refInfo:
+        sectionName, sectionData = section.strip().split(" ", 1)
+        if sectionName == "JOURNAL":
+            if "PUBMED" in sectionData:
+                sectionData, pubmed = sectionData.split("PUBMED")
+                reference["journal"] = _flattenBlock(sectionData)
+                reference["pubmed"] = pubmed.strip()
+
+        reference[sectionName.lower()] = _flattenBlock(sectionData)
+
+    if "references" not in entryData:
+        entryData["references"] = []
+
+    entryData["references"].append(reference)
+
+def _parseFeatures(heading: str, data: str, entryData: dict) -> None:
+    featureBlocks = _getSections(data, 5)
+    genes = {}
+    otherProperties = {}
+
+    for block in featureBlocks[1:]:
+        sectionHeader, sectionData = block.lstrip().split(" ", 1)
+
+        propertyList = _flattenBlock(sectionData, "//").split("///")
+        properties = {"bp_range": propertyList[0]}
+        for property in propertyList[1:]: # base pair range is first property in list
+            splitProperty = property.split("=")
+            if len(splitProperty) == 2:
+                key, value = splitProperty
+            else:
+                key = splitProperty[0]
+                value = key
+
+            properties[key] = value.strip('"')
+
+        if sectionHeader == "source":
+            value = properties.pop("organism", None)
+            if value is not None:
+                properties["features_organism"] = value
+
+            entryData |= properties
+
+        else:
+            gene = properties.get("gene", None)
+            if gene is not None:  # If section is associated with a gene
+                properties.pop("gene")
+                if gene not in genes:
+                    genes[gene] = {}
+
+                if sectionHeader not in genes[gene]:
+                    genes[gene][sectionHeader] = []
+
+                genes[gene][sectionHeader].append(properties)
+
+            else: # Not associated with a gene
+                if sectionHeader not in otherProperties:
+                    otherProperties[sectionHeader] = []
+
+                otherProperties[sectionHeader].append(properties)
+    
+    # Only write genes and other properties if exists
+    if genes:
+        entryData["genes"] = genes
+
+    if otherProperties:
+        entryData["other_properties"] = otherProperties
+
+def _parseOrigin(header: str, data: str, entryData: dict) -> None:
+    pass
+
+def _getSections(textBlock: str, whitespace: int = 0, allowDigits=True) -> list[str]:
+    sections = []
+    sectionStart = 0
+    searchPos = 0
+    textBlock = textBlock.rstrip("\n") # Make sure block doesn't end with newlines
+
+    while True:
+        nextNewlinePos = textBlock.find("\n", searchPos)
+        nextPlus1 = nextNewlinePos + 1
+
+        if nextNewlinePos < 0: # No next new line
+            sections.append(textBlock[sectionStart:])
+            break
+
+        if len(textBlock[nextPlus1:nextPlus1+whitespace+1].strip()) == 0: # No header on next line
+            searchPos = nextPlus1
+            continue
+
+        if not allowDigits and textBlock[nextPlus1+whitespace+1].isdigit(): # Check for digit leading next header
+            searchPos = nextPlus1
+            continue
+
+        sections.append(textBlock[sectionStart:nextNewlinePos])
+        sectionStart = searchPos = nextPlus1
+
+    return sections
+    
+def _flattenBlock(textBlock: str, joiner: str = " ") -> str:
+    return joiner.join(line.strip() for line in textBlock.split("\n") if line)

--- a/src/sourceProcessing/ncbiFlatfileParser.py
+++ b/src/sourceProcessing/ncbiFlatfileParser.py
@@ -41,10 +41,21 @@ def parseFlatfile(filePath: Path, verbose: bool = False) -> pd.DataFrame:
             entryData["fasta_url"] = f"{_genbankBaseURL}{version}{_fastaSuffix}"
 
         # Add specimen field
-        for value in (entryData.get("specimen_voucher", None), entryData.get("isolate", None), f"NCBI_{entryData['accession']}_specimen"):
+        specimenOptions = [
+            "specimen_voucher"
+            "isolate"
+            "accession"
+        ]
+
+        for idx, option in enumerate(specimenOptions, start=1):
+            value = entryData.get(option, None)
             if value is not None:
+                if idx == len(specimenOptions):
+                    value = f"NCBI_{value}_specimen"
                 entryData["specimen"] = value
                 break
+        else: # No specimen set
+            entryData["specimen"] = None
 
         records.append(entryData)
 

--- a/src/sourceProcessing/ncbiFlatfileParser.py
+++ b/src/sourceProcessing/ncbiFlatfileParser.py
@@ -270,10 +270,10 @@ def _parseFeatures(data: str) -> dict[str, str]:
     
     # Only write genes and other properties if exists
     if genes:
-        features["genes"] = genes
+        features["genes"] = str(genes)
 
     if otherProperties:
-        features["other_properties"] = otherProperties
+        features["other_properties"] = str(otherProperties)
 
     return features
 

--- a/src/sourceProcessing/ncbiFlatfileParser.py
+++ b/src/sourceProcessing/ncbiFlatfileParser.py
@@ -177,19 +177,31 @@ def _parseFeatures(heading: str, data: str, entryData: dict) -> None:
         propertyList = _flattenBlock(sectionData, "//").split("///")
         properties = {"bp_range": propertyList[0]}
         for property in propertyList[1:]: # base pair range is first property in list
-            splitProperty = property.split("=")
+            splitProperty = property.replace("//", "").split("=")
             if len(splitProperty) == 2:
                 key, value = splitProperty
             else:
                 key = splitProperty[0]
                 value = key
 
-            properties[key] = value.strip('"')
+            properties[key.strip('"')] = value.strip('"')
 
-        if sectionHeader == "source":
-            value = properties.pop("organism", None)
-            if value is not None:
-                properties["features_organism"] = value
+        if sectionHeader == "source": # Break out source section into separate columns
+            organism = properties.pop("organism", None)
+            if organism is not None:
+                properties["features_organism"] = organism
+
+            pcrPrimers = properties.pop("PCR_primers", None)
+            if pcrPrimers is not None:
+                pcrSections = pcrPrimers.split(",")
+
+                for section in pcrSections:
+                    if "_" not in section:
+                        properties["PCR_primers"] = section
+                        break
+
+                    key, value = section.split(":")
+                    properties[key.strip()] = value.strip()
 
             entryData |= properties
 


### PR DESCRIPTION
- Updated flatfile parser to use enums instead of strings
- Updated flatfile parser to no longer require nucleotide entry data to be passed around
- Updated ncbi processing so parseNucleotide now runs on the whole set, compiling a single csv
- Updated all nucleotide config files to reflect changes
- NCBI processing now forces overwrite when extracting files
- Added splitting out of references
- Added splitting out of PCR subfields
- Added support for subcategory representation on the mapping file with "::"
- GetFields now supports getting fields from only a small chunk of file