### PR TITLE
Big files and Progress

### DIFF
--- a/dataSources/ncbi/sharedProcessing.py
+++ b/dataSources/ncbi/sharedProcessing.py
@@ -76,7 +76,7 @@ def enrichStats(summaryFile: File, outputPath: Path, apiKeyPath: Path = None):
             else: # Record
                 recordData.append(value)
                 
-            progress.render((len(recordData) + len(failedAccessions)) / recordsPerSubsection)
+            progress.update((len(recordData) + len(failedAccessions)) / recordsPerSubsection)
 
         print(f"\nCompleted subsection {iteration}")
         writer.writeDF(pd.DataFrame.from_records(recordData))

--- a/src/lib/tools/bigFileWriter.py
+++ b/src/lib/tools/bigFileWriter.py
@@ -45,7 +45,7 @@ class Subfile:
         return pd.read_csv(self.filePath, **kwargs)
     
     def readChunks(self, chunkSize: int, **kwargs) -> Iterator[pd.DataFrame]:
-        return self.read(chunkSize=chunkSize, **kwargs)
+        return self.read(chunksize=chunkSize, **kwargs)
 
     def rename(self, newFilePath: Path, newFileFormat: Format) -> None:
         if newFileFormat == self.fileFormat:
@@ -147,8 +147,8 @@ class BigFileWriter:
     def getSubfileCount(self) -> int:
         return len(self.writtenFiles)
     
-    def subfileExists(self, name: str) -> bool:
-        return name in [subfile.fileName for subfile in self.writtenFiles]
+    def getSubfileNames(self) -> list[str]:
+        return [subfile.fileName for subfile in self.writtenFiles]
 
     def writeDF(self, df: pd.DataFrame, customName: str = "", format: Format = None) -> None:
         if not self.subfileDir.exists():

--- a/src/lib/tools/bigFileWriter.py
+++ b/src/lib/tools/bigFileWriter.py
@@ -201,15 +201,14 @@ class BigFileWriter:
         delim = "\t" if self.outputFileType == Format.TSV else ","
         chunkSize = 1024
 
+        # Create empty file with columns
+        pd.DataFrame(columns=self.globalColumns).to_csv(self.outputFile, mode="a", sep=delim, index=False)
+
         fileCount = len(self.writtenFiles)
         for idx, file in enumerate(self.writtenFiles):
             print(f"At file: {idx+1} / {fileCount}", end='\r')
 
-            for subIdx, chunk in enumerate(file.readChunks(chunkSize)):
-                if idx == subIdx == 0:
-                    chunk.to_csv(self.outputFile, mode="a", sep=delim, index=False)
-                    continue
-
+            for chunk in file.readChunks(chunkSize):
                 chunk.to_csv(self.outputFile, mode="a", sep=delim, index=False, header=False)
 
             if removeOld:

--- a/src/lib/tools/bigFileWriter.py
+++ b/src/lib/tools/bigFileWriter.py
@@ -120,8 +120,10 @@ class BigFileWriter:
             except OverflowError:
                 maxInt = int(maxInt/10)
 
-    def populateFromFolder(self, folderPath: Path, logIndividually: bool = False) -> None:
-        if not folderPath.exists():
+    def populateFromFolder(self, folderPath: Path = None, logIndividually: bool = False) -> None:
+        if folderPath is None:
+            folderPath = self.subfileDir
+        elif not folderPath.exists():
             return
         
         fileCount = 0

--- a/src/lib/tools/downloader.py
+++ b/src/lib/tools/downloader.py
@@ -40,7 +40,7 @@ class Downloader:
                         continue
                     
                     if fileSize > 0: # File size known, can render completion %
-                        self.progressBar.render((idx * chunksize) / fileSize)
+                        self.progressBar.update((idx * chunksize) / fileSize)
                     else:
                         print(f"Downloaded chunk: {idx}", end="\r")
 

--- a/src/tools/generic/parquetConverter.py
+++ b/src/tools/generic/parquetConverter.py
@@ -1,0 +1,14 @@
+import pandas as pd
+from argparse import ArgumentParser
+from pathlib import Path
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Convert parquet file to csv")
+    parser.add_argument("filepath", type=Path, help="Filepath of file to convert")
+    args = parser.parse_args()
+
+    if not args.filepath.exists():
+        print(f"No file found at path: {args.filepath}")
+        exit()
+
+    pd.read_parquet(args.filepath).to_csv(args.filepath.parent / f"{args.filepath.stem}.csv", index=False)


### PR DESCRIPTION
- Added a simple parquet converter to convert parquet files to csv with the same name in the same directory
- Updated ProgressBars to now have normal, updatable, and steppable versions
- Updated BigFileWriter populateFromFolder to now default to it's defined subfile directory
- Updated subfileExists to getSubfileNames as the former was inefficient for repeated calls
- Updated BigFileWriter to now use a progress bar for displaying oneFile combine progress
- Fixed a bug with BigFileWriter where not all columns were being added to the header in specific situations