### PR TITLE
Download Metadata Fixes

### DIFF
--- a/src/lib/systemManagers/downloading.py
+++ b/src/lib/systemManagers/downloading.py
@@ -77,7 +77,7 @@ class DownloadManager:
             success = download.retrieve(overwrite, verbose)
 
             metadata["files"].append({
-                "output": download.file.filePath,
+                "output": download.file.filePath.name,
                 "success": success,
                 "duration": time.perf_counter() - downloadStart,
                 "timestamp": datetime.now().isoformat()

--- a/src/lib/systemManagers/metadata.py
+++ b/src/lib/systemManagers/metadata.py
@@ -15,12 +15,16 @@ class MetadataManager:
         self._load()
         
     def _load(self) -> None:
-        if not self.metadataPath.exists():
-            self.data = {}
-            return
-        
-        with open(self.metadataPath) as fp:
-            self.data = json.load(fp)
+        if self.metadataPath.exists():       
+            try:
+                with open(self.metadataPath) as fp:
+                    self.data = json.load(fp)
+                    return
+                
+            except json.JSONDecodeError:
+                self.metadataPath.unlink()
+
+        self.data = {}
 
     def _save(self) -> None:
         with open(self.metadataPath, "w") as fp:


### PR DESCRIPTION
- Updated downloading systemManager to properly pass output filename in metadata
- Updated metadata systemManager to purge old metadata file if malformed