### PR TITLE
Script revamp

### DIFF
--- a/dataSources/ncbi/genbank/config.json
+++ b/dataSources/ncbi/genbank/config.json
@@ -29,28 +29,12 @@
     },
     "conversion": {
         "mapID": 2003682060,
-        "customMapPath": "./customColumns.json",
-        "setNA": [
-            "na"
-        ],
-        "fillNA": {
-            "assemblies": {
-                "datasetID": {
-                    "assemblies": [
-                        "sequence_id"
-                    ],
-                    "annotations": [
-                        "sequence_id"
-                    ],
-                    "depositions": [
-                        "sequence_id"
-                    ],
-                    "sequences": [
-                        "record_id"
-                    ]
-                }
+        "augment": [
+            {
+                "path": "../sharedProcessing.py",
+                "function": "genbankAugment"
             }
-        }
+        ]
     },
     "update": {
         "type": "weekly",

--- a/dataSources/ncbi/refseq/config.json
+++ b/dataSources/ncbi/refseq/config.json
@@ -29,28 +29,12 @@
     },
     "conversion": {
         "mapID": 2003682060,
-        "customMapPath": "./customColumns.json",
-        "setNA": [
-            "na"
-        ],
-        "fillNA": {
-            "assemblies": {
-                "datasetID": {
-                    "assemblies": [
-                        "sequence_id"
-                    ],
-                    "annotations": [
-                        "sequence_id"
-                    ],
-                    "depositions": [
-                        "sequence_id"
-                    ],
-                    "sequences": [
-                        "record_id"
-                    ]
-                }
+        "augment": [
+            {
+                "path": "../sharedProcessing.py",
+                "function": "genbankAugment"
             }
-        }
+        ]
     },
     "update": {
         "type": "weekly",

--- a/src/lib/processing/mapping.py
+++ b/src/lib/processing/mapping.py
@@ -15,7 +15,7 @@ class Event(Enum):
     SUBSAMPLE = "subsamples"
     EXTRACTION = "dna_extractions"
     SEQUENCE = "sequences"
-    ASSEMBLIE = "assemblies"
+    ASSEMBLIES = "assemblies"
     ANNOTATION = "annotations"
     DEPOSITION = "depositions"
     UNMAPPED = "unmapped"

--- a/src/lib/systemManagers/conversion.py
+++ b/src/lib/systemManagers/conversion.py
@@ -131,7 +131,7 @@ class ConversionManager(SystemManager):
 
     def applyAugments(self, df: pd.DataFrame) -> pd.DataFrame | None:
         for augment in self.augments:
-            success, df = augment.run(True, inputArgs=[df])
+            success, df = augment.run(False, inputArgs=[df])
 
             if not success:
                 return None

--- a/src/lib/systemManagers/conversion.py
+++ b/src/lib/systemManagers/conversion.py
@@ -5,13 +5,14 @@ import lib.commonFuncs as cmn
 from lib.tools.bigFileWriter import BigFileWriter
 from lib.processing.mapping import Remapper, Event
 from lib.processing.stages import File, StackedFile
-from lib.processing.scripts import Script
+from lib.processing.scripts import FunctionScript
 from lib.systemManagers.baseManager import SystemManager, Metadata
 from lib.tools.logger import Logger
 import gc
 import time
 from datetime import datetime
 import lib.tools.zipping as zp
+from typing import Generator
 
 class ConversionManager(SystemManager):
     def __init__(self, baseDir: Path, converionDir: Path, datasetID: str, location: str, database: str, subsection: str):
@@ -33,12 +34,10 @@ class ConversionManager(SystemManager):
         self.customMapPath = properties.pop("customMapPath", None)
 
         self.chunkSize = properties.pop("chunkSize", 1024)
-        self.setNA = properties.pop("setNA", [])
-        self.fillNA = ColumnFiller(properties.pop("fillNA", {}))
         self.skipRemap = properties.pop("skipRemap", [])
         self.preserveDwC = properties.pop("preserveDwC", False)
         self.prefixUnmapped = properties.pop("prefixUnmapped", True)
-        self.augments = [Script(self.baseDir, self.conversionDir, augProperties, []) for augProperties in properties.pop("augment", [])]
+        self.augments = [FunctionScript(self.baseDir, augProperties) for augProperties in properties.pop("augment", [])]
 
         self.remapper = Remapper(mapDir, self.mapID, self.customMapID, self.customMapPath, self.location, self.preserveDwC, self.prefixUnmapped)
         self.fileLoaded = True
@@ -90,13 +89,21 @@ class ConversionManager(SystemManager):
                 print(f"At chunk: {idx}", end='\r')
 
             df = self.remapper.applyTranslation(df) # Returns a multi-index dataframe
-            for na in self.setNA:
-                df = df.replace(na, np.NaN)
-
-            df = self.fillNA.apply(df)
             df = self.applyAugments(df)
-            df[(Event.COLLECTION, "dataset_id")] = self.datasetID
-            df[(Event.COLLECTION, "entity_id")] = df[(Event.COLLECTION, "dataset_id")] + df[(Event.COLLECTION, "scientific_name")]
+
+            if df is None:
+                return False
+
+            datasetID = "dataset_id"
+            scientificName = "scientific_name"
+            entityID = "entity_id"
+
+            if scientificName not in df[Event.COLLECTION].columns:
+                Logger.error(f"Unable to generate '{entityID}' as dataset is missing field '{scientificName}' in event '{Event.COLLECTION.value}'")
+                return False
+            
+            df[(Event.COLLECTION, datasetID)] = self.datasetID
+            df[(Event.COLLECTION, entityID)] = df[(Event.COLLECTION, datasetID)] + df[(Event.COLLECTION, scientificName)]
 
             for eventColumn in df.columns.levels[0]:
                 writers[eventColumn].writeDF(df[eventColumn])
@@ -122,9 +129,17 @@ class ConversionManager(SystemManager):
         
         return True
 
-    def applyAugments(self, df: pd.DataFrame) -> pd.DataFrame:
+    def applyAugments(self, df: pd.DataFrame) -> pd.DataFrame | None:
         for augment in self.augments:
-            df = augment.run(args=[df])
+            success, df = augment.run(True, inputArgs=[df])
+
+            if not success:
+                return None
+
+            if not isinstance(df, pd.DataFrame):
+                Logger.error(f"Augment '{augment.function}' does not output dataframe as required, instead output {type(df)}")
+                return None
+            
         return df
     
     def package(self, compressLocation: Path) -> Path:
@@ -132,28 +147,3 @@ class ConversionManager(SystemManager):
         outputPath = zp.compress(self.output.filePath, compressLocation)
         renamedFile.rename(self.metadataPath)
         return outputPath
-    
-class ColumnFiller:
-    def __init__(self, fillProperties: dict[str, dict]):
-        self.fillProperties = fillProperties
-
-        for event, columns in self.fillProperties.items():
-            if not self._validEvent(event):
-                raise Exception(f"Unknown event: {event}") from AttributeError
-            
-            for mapToDict in columns.values():
-                for mapToEvent in mapToDict:
-                    if not self._validEvent(mapToEvent):
-                        raise Exception(f"Unknown mapTo event: {event}") from AttributeError
-
-    def _validEvent(self, event: str) -> bool:
-        return event in Event._value2member_map_
-    
-    def apply(self, df: pd.DataFrame) -> pd.DataFrame:
-        for event, columns in self.fillProperties.items():
-            for columnName, mapTo in columns.items():
-                for mapToEvent, mapToColumnList in mapTo.items():
-                    for mapToColumn in mapToColumnList:
-                        df[(mapToEvent, mapToColumn)].fillna(df[(event, columnName)], inplace=True)
-
-        return df

--- a/src/lib/systemManagers/downloading.py
+++ b/src/lib/systemManagers/downloading.py
@@ -1,11 +1,9 @@
 from pathlib import Path
 from lib.systemManagers.baseManager import SystemManager, Task
 from lib.processing.stages import File
-from lib.processing.scripts import Script
+from lib.processing.scripts import OutputScript
 from lib.tools.logger import Logger
 import lib.tools.downloading as dl
-import time
-from datetime import datetime
 
 class _Download(Task):
     def __init__(self, filePath: Path, properties: dict):
@@ -31,7 +29,7 @@ class _URLDownload(_Download):
 
 class _ScriptDownload(_Download):
     def __init__(self, baseDir: Path, downloadDir: Path, scriptInfo: dict):
-        self.script = Script(baseDir, downloadDir, dict(scriptInfo), [])      
+        self.script = OutputScript(baseDir, dict(scriptInfo), downloadDir)      
 
         super().__init__(self.script.output.filePath, self.script.outputProperties)
 

--- a/src/lib/systemManagers/processing.py
+++ b/src/lib/systemManagers/processing.py
@@ -1,13 +1,11 @@
 from pathlib import Path
 from lib.processing.stages import File
-from lib.processing.scripts import Script
+from lib.processing.scripts import FileScript
 from lib.systemManagers.baseManager import SystemManager, Task
 from lib.tools.logger import Logger
-import time
-from datetime import datetime
 
 class _Node(Task):
-    def __init__(self, index: int, script: Script, parents: list['_Node']):
+    def __init__(self, index: int, script: FileScript, parents: list['_Node']):
         self.index = index
         self.script = script
         self.parents = parents
@@ -61,7 +59,7 @@ class ProcessingManager(SystemManager):
     def _createNode(self, step: dict, parents: list[_Node]) -> _Node | None:
         inputs = [node.getOutputFile() for node in parents]
         try:
-            script = Script(self.baseDir, self.processingDir, dict(step), inputs)
+            script = FileScript(self.baseDir, dict(step), self.processingDir, inputs)
         except AttributeError as e:
             Logger.error(f"Invalid processing script configuration: {e}")
             return None

--- a/src/tools/source/viewConversion.py
+++ b/src/tools/source/viewConversion.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     delim = "\t" if args.tsv else ","
 
     for source in sources:
-        source._prepare(Step.CONVERSION)
+        source._prepare(Step.CONVERSION, False, True)
         dwcFile = source.conversionManager.output
 
         if not dwcFile.filePath.exists():


### PR DESCRIPTION
- Updated singular Script object attempting to handle all cases into sub-classes that handle different types of scripts
- Updated Downloading, Processing, and Conversion managers to now use relevant script type for their task
- Removed ConversionManagers setNA and fillNA fields, as this type of task should be handled by conversion augments
- Updated NCBI refseq and genbank to use an augment for previous setNA and fillNA functions on Conversion Manager
- Fixed a typo in assemblies event in mapping
- Fixed missing required variables for a call in viewConversion.py