### PR TITLE
System Naming

### DIFF
--- a/dataSources/42bp/genomeArk/config.json
+++ b/dataSources/42bp/genomeArk/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000193",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "build",
         "args": [

--- a/dataSources/afd/checklist/config.json
+++ b/dataSources/afd/checklist/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0001000",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "retrieve",
         "args": [

--- a/dataSources/ala/avh/config.json
+++ b/dataSources/ala/avh/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "0007001",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "build",
         "args": [

--- a/dataSources/ala/lists/config.json
+++ b/dataSources/ala/lists/config.json
@@ -1,6 +1,6 @@
 {
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "collect",
         "args": [

--- a/dataSources/ala/profiles/config.json
+++ b/dataSources/ala/profiles/config.json
@@ -7,7 +7,7 @@
         "mangrovewatch": {},
         "weeds-australia": {}
     },
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "collect",
         "args": [

--- a/dataSources/algaeBase/api/config.json
+++ b/dataSources/algaeBase/api/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0003001",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "build",
         "args": [

--- a/dataSources/anemone/db/config.json
+++ b/dataSources/anemone/db/config.json
@@ -2,7 +2,7 @@
     "datasetID": "ARGA:TL:0000174",
     "retrieveType": "crawl",
     "auth": "auth.txt",
-    "download": {
+    "downloading": {
         "url": "https://db.anemone.bio/dist/",
         "regex": ".*\\.tsv\\.xz",
         "prefix": true

--- a/dataSources/bold/austsv/config.json
+++ b/dataSources/bold/austsv/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000175",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "http://v4.boldsystems.org/index.php/API_Public/combined?geo=Australia&format=tsv",

--- a/dataSources/bold/ausxml/config.json
+++ b/dataSources/bold/ausxml/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000176",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "http://v4.boldsystems.org/index.php/API_Public/combined?geo=Australia&format=xml",

--- a/dataSources/bold/datapackage/config.json
+++ b/dataSources/bold/datapackage/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0004000",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "retrieve",
         "output": "datapackage.tar.gz"

--- a/dataSources/bpa/portal/config.json
+++ b/dataSources/bpa/portal/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0005000",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "build",
         "args": [

--- a/dataSources/bvbrc/db/config.json
+++ b/dataSources/bvbrc/db/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000194",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "ftp://ftp.bvbrc.org/RELEASE_NOTES/genome_metadata",

--- a/dataSources/col/db/config.json
+++ b/dataSources/col/db/config.json
@@ -1,7 +1,7 @@
 {
     "retrieveType": "url",
     "datasetID": "ARGA:TL:0001018",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://api.checklistbank.org/dataset/304708/export.zip?extended=true&format=DwCA",

--- a/dataSources/csiro/api/config.json
+++ b/dataSources/csiro/api/config.json
@@ -8,7 +8,7 @@
         }
     },
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "build",
         "args": [

--- a/dataSources/csiro/dap/config.json
+++ b/dataSources/csiro/dap/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000178",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "getPortalData",
         "args": [

--- a/dataSources/dnazoo/db/config.json
+++ b/dataSources/dnazoo/db/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000181",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "build",
         "args": [

--- a/dataSources/ena/assembly/config.json
+++ b/dataSources/ena/assembly/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0002005",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://www.ebi.ac.uk/ena/portal/api/search?result=assembly&fields=all&limit=0&format=tsv",

--- a/dataSources/ena/genome/config.json
+++ b/dataSources/ena/genome/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0002006",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://ftp.ebi.ac.uk/pub/databases/ena/genome_collections/gc.xml",

--- a/dataSources/ena/taxonomy/config.json
+++ b/dataSources/ena/taxonomy/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0002004",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://ftp.ebi.ac.uk/pub/databases/ena/taxonomy/taxonomy.xml.gz",

--- a/dataSources/ena/variant/config.json
+++ b/dataSources/ena/variant/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0002007",
     "retrieveType": "crawl",
-    "download": {
+    "downloading": {
         "url": "https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_4/by_species/",
         "regex": ".*\\.txt\\.gz",
         "depth": -1

--- a/dataSources/ensembl/genomes/config.json
+++ b/dataSources/ensembl/genomes/config.json
@@ -18,7 +18,7 @@
         }
     },
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "http://ftp.ensemblgenomes.org/pub/{SUBSECTION}/current/species_metadata_Ensembl{SUBSECTION:NAME}.json",

--- a/dataSources/ensembl/species/config.json
+++ b/dataSources/ensembl/species/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0002013",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "sourceProcessing/ensembl.py",
         "function": "speciesDownload",
         "args": [

--- a/dataSources/ensembl/vgp/config.json
+++ b/dataSources/ensembl/vgp/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0002014",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "sourceProcessing/ensembl.py",
         "function": "collectVGP",
         "args": [

--- a/dataSources/esa178/db/config.json
+++ b/dataSources/esa178/db/config.json
@@ -11,7 +11,7 @@
         }
     },
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://www.esapubs.org/archive/ecol/E095/178/{SUBSECTION:NAME}FuncDat.txt",

--- a/dataSources/goat/db/config.json
+++ b/dataSources/goat/db/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000184",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "build",
         "args": [

--- a/dataSources/gsa/db/config.json
+++ b/dataSources/gsa/db/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "build",
         "args": [

--- a/dataSources/i5k/organisms/config.json
+++ b/dataSources/i5k/organisms/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000185",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "retrieve",
         "args": [

--- a/dataSources/itis/db/config.json
+++ b/dataSources/itis/db/config.json
@@ -1,7 +1,7 @@
 {
     "retrieveType": "url",
     "datasetID": "ARGA:TL:0001016",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://www.itis.gov/downloads/itisSqlite.zip",

--- a/dataSources/iucn/api/config.json
+++ b/dataSources/iucn/api/config.json
@@ -1,6 +1,6 @@
 {
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "retrieve",
         "args": [

--- a/dataSources/kew/powo/config.json
+++ b/dataSources/kew/powo/config.json
@@ -1,7 +1,7 @@
 {
     "retrieveType": "url",
     "datasetID": "ARGA:TL:0001021",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://sftp.kew.org/pub/data-repositories/WCVP/wcvp_dwca.zip",

--- a/dataSources/ncbi/biocollections/config.json
+++ b/dataSources/ncbi/biocollections/config.json
@@ -1,6 +1,6 @@
 {
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://ftp.ncbi.nih.gov/pub/taxonomy/biocollections/Collection_codes.txt",

--- a/dataSources/ncbi/bioproject/config.json
+++ b/dataSources/ncbi/bioproject/config.json
@@ -1,6 +1,6 @@
 {
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://ftp.ncbi.nlm.nih.gov/bioproject/bioproject.xml",    

--- a/dataSources/ncbi/biosample/config.json
+++ b/dataSources/ncbi/biosample/config.json
@@ -1,6 +1,6 @@
 {
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://ftp.ncbi.nlm.nih.gov/biosample/biosample_set.xml.gz",

--- a/dataSources/ncbi/genbank/config.json
+++ b/dataSources/ncbi/genbank/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0002003",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://ftp.ncbi.nih.gov/genomes/genbank/assembly_summary_genbank.txt",

--- a/dataSources/ncbi/gene/config.json
+++ b/dataSources/ncbi/gene/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000161",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/All_Data.gene_info.gz",

--- a/dataSources/ncbi/nucleotide/config.json
+++ b/dataSources/ncbi/nucleotide/config.json
@@ -57,7 +57,7 @@
         }
     },
     "retrieveType": "crawl",
-    "download": {
+    "downloading": {
         "url": "https://ftp.ncbi.nlm.nih.gov/genbank/",
         "regex": "gb{SUBSECTION:NAME}\\d+\\.seq\\.gz",
         "maxDepth": 0

--- a/dataSources/ncbi/refseq/config.json
+++ b/dataSources/ncbi/refseq/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0002002",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://ftp.ncbi.nih.gov/genomes/refseq/assembly_summary_refseq.txt",

--- a/dataSources/ncbi/taxonomy/config.json
+++ b/dataSources/ncbi/taxonomy/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0002000",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdmp.zip",

--- a/dataSources/ncbi/tpa/config.json
+++ b/dataSources/ncbi/tpa/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000167",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://ftp.ncbi.nlm.nih.gov/tpa/release/con_tpa_cu.gbff.gz",

--- a/dataSources/nsl/apc/config.json
+++ b/dataSources/nsl/apc/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://biodiversity.org.au/nsl/services/export/taxonCsv",

--- a/dataSources/pilbseq/explorer/config.json
+++ b/dataSources/pilbseq/explorer/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000186",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://pilbseq.dbca.wa.gov.au/data/table.tsv",

--- a/dataSources/reefGenomics/db/config.json
+++ b/dataSources/reefGenomics/db/config.json
@@ -5,7 +5,7 @@
         "organism": {}
     },
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "build",
         "args": [

--- a/dataSources/silva/metadata/config.json
+++ b/dataSources/silva/metadata/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "",
     "retrieveType": "crawl",
-    "download": {
+    "downloading": {
         "location": "https://www.arb-silva.de/no_cache/download/archive/current/Exports/full_metadata/",
         "link": "https://www.arb-silva.de/",
         "regex": ".*\\.gz$",

--- a/dataSources/tern/portal/config.json
+++ b/dataSources/tern/portal/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000188",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "build",
         "args": [

--- a/dataSources/tsi/compiled/config.json
+++ b/dataSources/tsi/compiled/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "./processing.py",
         "function": "manualCollect",
         "args": [

--- a/dataSources/tsi/koala/config.json
+++ b/dataSources/tsi/koala/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0008000",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://koalagenomes.s3.ap-southeast-2.amazonaws.com/Koala_Metadata-19-10-2022.csv",

--- a/dataSources/tsi/mouse/config.json
+++ b/dataSources/tsi/mouse/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000196",
     "retrieveType": "url",
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://threatenedspecies.s3-ap-southeast-2.amazonaws.com/Mastacomys_fuscus/BTR_Metadata.csv",

--- a/dataSources/vicMuseum/species/config.json
+++ b/dataSources/vicMuseum/species/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000190",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "../processing.py",
         "function": "retrieve",
         "args": [

--- a/dataSources/vicMuseum/specimens/config.json
+++ b/dataSources/vicMuseum/specimens/config.json
@@ -1,7 +1,7 @@
 {
     "datasetID": "ARGA:TL:0000191",
     "retrieveType": "script",
-    "download": {
+    "downloading": {
         "path": "../processing.py",
         "function": "retrieve",
         "args": [

--- a/dataSources/wilderlab/aws/config.json
+++ b/dataSources/wilderlab/aws/config.json
@@ -5,7 +5,7 @@
         "records": {},
         "samples": {}
     },
-    "download": {
+    "downloading": {
         "files": [
             {
                 "url": "https://s3.ap-southeast-2.amazonaws.com/wilderlab.publicdata/{SUBSECTION}3.csv",

--- a/src/lib/data/database.py
+++ b/src/lib/data/database.py
@@ -30,15 +30,6 @@ class BasicDB:
         # Auth
         self.authFile: str = config.pop("auth", "")
 
-        # Config stages
-        self.downloadConfig: dict = config.pop("download", None)
-        self.processingConfig: dict = config.pop("processing", {})
-        self.conversionConfig: dict = config.pop("conversion", {})
-        self.updateConfig: dict = config.pop("update", {})
-
-        if self.downloadConfig is None:
-            raise Exception("No download config specified as required") from AttributeError
-
         # Relative folders
         self.locationDir = cfg.Folders.dataSources / location
         self.databaseDir = self.locationDir / database
@@ -49,6 +40,17 @@ class BasicDB:
         self.downloadManager = DownloadManager(self.dataDir, self.authFile)
         self.processingManager = ProcessingManager(self.dataDir)
         self.conversionManager = ConversionManager(self.dataDir, self.datasetID, location, database, subsection)
+
+        # Config stages
+        self.downloadConfig: dict = config.pop(self.downloadManager.stepName, None)
+        self.processingConfig: dict = config.pop(self.processingManager.stepName, {})
+        self.conversionConfig: dict = config.pop(self.conversionManager.stepName, {})
+
+        if self.downloadConfig is None:
+            raise Exception("No download config specified as required") from AttributeError
+        
+        # Updating
+        self.updateConfig: dict = config.pop("updating", {})
         self.updateManager = UpdateManager(self.updateConfig)
 
         # Report extra config options

--- a/src/lib/data/database.py
+++ b/src/lib/data/database.py
@@ -44,14 +44,11 @@ class BasicDB:
         self.databaseDir = self.locationDir / database
         self.subsectionDir = self.databaseDir / self.subsection # If no subsection, does nothing
         self.dataDir = self.subsectionDir / "data"
-        self.downloadDir = self.dataDir / "download"
-        self.processingDir = self.dataDir / "processing"
-        self.convertedDir = self.dataDir / "converted"
 
         # System Managers
-        self.downloadManager = DownloadManager(self.subsectionDir, self.downloadDir, self.authFile)
-        self.processingManager = ProcessingManager(self.subsectionDir, self.processingDir)
-        self.conversionManager = ConversionManager(self.subsectionDir, self.convertedDir, self.datasetID, location, database, subsection)
+        self.downloadManager = DownloadManager(self.dataDir, self.authFile)
+        self.processingManager = ProcessingManager(self.dataDir)
+        self.conversionManager = ConversionManager(self.dataDir, self.datasetID, location, database, subsection)
         self.updateManager = UpdateManager(self.updateConfig)
 
         # Report extra config options

--- a/src/lib/data/sources.py
+++ b/src/lib/data/sources.py
@@ -156,10 +156,14 @@ class Database:
         dbs = []
         for subsectionName, configData in configs.items():
             datasetID, config = configData
+            databaseName = f"{self.locationName}-{self.databaseName}{f'-{subsectionName}' if subsectionName else ''}"
+
             try:
-                Logger.info(f"Creating database '{self.locationName}-{self.databaseName}{f'-{subsectionName}' if subsectionName else ''}'")
+                Logger.info(f"Creating database '{databaseName}'")
                 dbs.append(dbType(self.locationName, self.databaseName, subsectionName, datasetID, config))
-            except AttributeError:
+            except AttributeError as e:
+                Logger.error(f"Error creating database '{databaseName}' - {e}")
+                Logger.error()
                 continue
 
         return dbs

--- a/src/lib/systemManagers/conversion.py
+++ b/src/lib/systemManagers/conversion.py
@@ -15,10 +15,12 @@ import lib.tools.zipping as zp
 from typing import Generator
 
 class ConversionManager(SystemManager):
-    def __init__(self, baseDir: Path, converionDir: Path, datasetID: str, location: str, database: str, subsection: str):
-        super().__init__(baseDir, "converting", "tasks")
+    def __init__(self, dataDir: Path, datasetID: str, location: str, database: str, subsection: str):
+        self.stepName = "convert"
 
-        self.conversionDir = converionDir
+        super().__init__(dataDir.parent, self.stepName, "tasks")
+
+        self.conversionDir = dataDir / self.stepName
         self.location = location
         self.datasetID = datasetID
 

--- a/src/lib/systemManagers/conversion.py
+++ b/src/lib/systemManagers/conversion.py
@@ -16,7 +16,7 @@ from typing import Generator
 
 class ConversionManager(SystemManager):
     def __init__(self, dataDir: Path, datasetID: str, location: str, database: str, subsection: str):
-        self.stepName = "convert"
+        self.stepName = "conversion"
 
         super().__init__(dataDir.parent, self.stepName, "tasks")
 

--- a/src/lib/systemManagers/downloading.py
+++ b/src/lib/systemManagers/downloading.py
@@ -37,10 +37,12 @@ class _ScriptDownload(_Download):
         return self.script.run(overwrite, verbose)
 
 class DownloadManager(SystemManager):
-    def __init__(self, baseDir: Path, downloadDir: Path, authFile: str):
-        super().__init__(baseDir, "downloading", "files")
+    def __init__(self, dataDir: Path, authFile: str):
+        self.stepName = "download"
 
-        self.downloadDir = downloadDir
+        super().__init__(dataDir.parent, self.stepName, "files")
+
+        self.downloadDir = dataDir / self.stepName
         self.authFile = authFile
 
         authPath = self.baseDir / self.authFile

--- a/src/lib/systemManagers/downloading.py
+++ b/src/lib/systemManagers/downloading.py
@@ -38,7 +38,7 @@ class _ScriptDownload(_Download):
 
 class DownloadManager(SystemManager):
     def __init__(self, dataDir: Path, authFile: str):
-        self.stepName = "download"
+        self.stepName = "downloading"
 
         super().__init__(dataDir.parent, self.stepName, "files")
 

--- a/src/lib/systemManagers/processing.py
+++ b/src/lib/systemManagers/processing.py
@@ -50,7 +50,7 @@ class _Root(_Node):
 
 class ProcessingManager(SystemManager):
     def __init__(self, dataDir: Path):
-        self.stepName = "process"
+        self.stepName = "processing"
 
         super().__init__(dataDir.parent, self.stepName, "steps")
 

--- a/src/lib/systemManagers/processing.py
+++ b/src/lib/systemManagers/processing.py
@@ -49,10 +49,12 @@ class _Root(_Node):
         return True
 
 class ProcessingManager(SystemManager):
-    def __init__(self, baseDir: Path, processingDir: Path):
-        super().__init__(baseDir, "processing", "steps")
+    def __init__(self, dataDir: Path):
+        self.stepName = "process"
 
-        self.processingDir = processingDir
+        super().__init__(dataDir.parent, self.stepName, "steps")
+
+        self.processingDir = dataDir / self.stepName
         self.nodes: list[_Node] = []
         self._nodeIndex = 0
 

--- a/src/tools/source/newSource.py
+++ b/src/tools/source/newSource.py
@@ -8,7 +8,7 @@ from lib.data.database import Retrieve
 def _urlConfig() -> dict:
     return {
         "retrieveType": "url",
-        "download": {
+        "downloading": {
             "files": [
                 {
                     "url": "",
@@ -22,7 +22,7 @@ def _urlConfig() -> dict:
 def _crawlConfig() -> dict:
     return {
         "retrieveType": "crawl",
-        "download": {
+        "downloading": {
             "url": "",
             "regex": ""
         },
@@ -32,7 +32,7 @@ def _crawlConfig() -> dict:
 def _scriptConfig() -> dict:
     return {
         "retrieveType": "script",
-        "download": {
+        "downloading": {
             "path": "",
             "function": "",
             "args": [],
@@ -44,7 +44,7 @@ def _scriptConfig() -> dict:
 def _defaultConfig() -> dict:
     return {
         "retrieveType": "",
-        "download": {},
+        "downloading": {},
         "conversion": {}
     }
 


### PR DESCRIPTION
- No longer create download/processing/conversion directories in Database
- Each systemManager now only takes the dataDir and determines their working directory based on their step name property
- Step name property now also passed to parent so working directory name matches name in metadata
- Updated download/process/convert names to downloading/processing/conversion respectively
- Each stage's config is now retrieved using the system manager stepName property
- Renamed every config files download step to downloading, inline with the download system manager
- Fixed a bug where failed database initialisations were not being reported and logged