### PR TITLE
Lib Updates

### DIFF
--- a/src/lib/bigFileWriter.py
+++ b/src/lib/bigFileWriter.py
@@ -132,7 +132,8 @@ class BigFileWriter:
     def populateFromFolder(self, folderPath: Path = None, logIndividually: bool = False) -> None:
         if folderPath is None:
             folderPath = self.subfileDir
-        elif not folderPath.exists():
+            
+        if not folderPath.exists():
             return
         
         fileCount = 0

--- a/src/lib/progressBar.py
+++ b/src/lib/progressBar.py
@@ -42,7 +42,7 @@ class UpdatableProgressBar(ProgressBar):
         if self._completed:
             return
         
-        outputLen = super().update(atTask / self.taskCount, extraInfo)
+        outputLen = super().update(atTask / max(1, self.taskCount), extraInfo)
 
         if atTask == self.taskCount:
             self._completed = True

--- a/src/lib/systemManagers/downloading.py
+++ b/src/lib/systemManagers/downloading.py
@@ -31,7 +31,7 @@ class _ScriptDownload(_Download):
     def __init__(self, baseDir: Path, downloadDir: Path, scriptInfo: dict):
         self.script = OutputScript(baseDir, dict(scriptInfo), downloadDir)      
 
-        super().__init__(self.script.output.filePath, self.script.outputProperties)
+        super().__init__(self.script.output.filePath, self.script.output.fileProperties)
 
     def runTask(self, overwrite: bool, verbose: bool) -> bool:
         return self.script.run(overwrite, verbose)

--- a/src/lib/zipping.py
+++ b/src/lib/zipping.py
@@ -35,10 +35,14 @@ def extract(filePath: Path, outputDir: Path = None, addSuffix: str = "", overwri
     
     outputPath = extractsTo(filePath, outputDir, addSuffix)
     if outputPath.exists() and not overwrite:
-        logging.info(f"Output {outputPath.name} exists, skipping extraction stage")
+        if verbose:
+            logging.info(f"Output {outputPath.name} exists, skipping extraction stage")
+            
         return outputPath
 
-    logging.info(f"Extracting {filePath} to {outputPath}")
+    if verbose:
+        logging.info(f"Extracting {filePath} to {outputPath}")
+
     shutil.unpack_archive(filePath, outputPath)
     return outputPath
 


### PR DESCRIPTION
- Added a fix for BigFileWriter when populating from a folder that doesn't exist
- Fixed a divide by 0 error in ProgressBar
- Fixed invalid reference to output properties in Downloading
- Added temporary verbose check for logging zipping actions