### PR TITLE
Metadata fixes

### DIFF
--- a/src/lib/crawler.py
+++ b/src/lib/crawler.py
@@ -70,6 +70,9 @@ class Crawler:
             self._save()
             logging.info(f"Successfully retrieved entry url {entryURL}, crawling subfolders")
         else:
+            if len(self.data) >= maxDepth:
+                return # Exit early if no crawling necessary
+            
             logging.info(f"Progress found, resuming crawling at depth: {len(self.data)}")
 
         while len(self.data) <= maxDepth:

--- a/src/lib/data/argParser.py
+++ b/src/lib/data/argParser.py
@@ -10,10 +10,10 @@ class ArgParser:
         self._manager = SourceManager()
 
         self.addArgument("source", help="Data set to interact with", metavar="SOURCE")
-        self.addArgument("-q", "--quiet", action="store_false", help="Suppress output during execution")
+        self.addArgument("-q", f"--{Flag.VERBOSE.value}", action="store_false", help="Suppress output during execution")
 
-        self.addArgument("-p", "--reprepare", action="store_true", help=reprepareHelp)
-        self.addArgument("-o", "--overwrite", action="store_true", help=overwriteHelp)
+        self.addArgument("-p", f"--{Flag.REPREPARE.value}", action="store_true", help=reprepareHelp)
+        self.addArgument("-o", f"--{Flag.OVERWRITE.value}", action="store_true", help=overwriteHelp)
 
     def addArgument(self, *args, **kwargs) -> None:
         self._parser.add_argument(*args, **kwargs)
@@ -27,13 +27,7 @@ class ArgParser:
             if not passed:
                 sources = []
 
-        flagMap = {
-            "quiet": Flag.VERBOSE,
-            "reprepare": Flag.REPREPARE,
-            "overwrite": Flag.OVERWRITE
-        }
-
-        flags = [flag for key, flag in flagMap.items() if self._extract(parsedArgs, key)]
+        flags = [flag for key, flag in Flag._value2member_map_.items() if self._extract(parsedArgs, key)]
 
         return sources, flags, parsedArgs.__dict__ if kwargsDict else parsedArgs
 

--- a/src/lib/data/argParser.py
+++ b/src/lib/data/argParser.py
@@ -1,26 +1,27 @@
-import argparse
+from argparse import ArgumentParser, Namespace, _MutuallyExclusiveGroup
 from lib.data.sources import SourceManager
 from lib.data.database import BasicDB, Flag
 
 class ArgParser:
-    def __init__(self, description=""):
+    def __init__(self, description: str = "", reprepareHelp: str = "Force redoing source preparation", overwriteHelp: str = "Force overwriting all output"):
         self.sourceWarning = 4
-        self.parser = argparse.ArgumentParser(description=description)
-        self.manager = SourceManager()
 
-        self.parser.add_argument("source", help="Data set to interact with", metavar="SOURCE")
-        self.parser.add_argument("-p", "--prepare", action="store_true", help="Force redoing preparation")
-        self.parser.add_argument("-o", "--overwrite", action="store_true", help="Force overwriting output")
-        self.parser.add_argument("-u", "--update", action="store_true", help="Run update version of database if available")
-        self.parser.add_argument("-q", "--quiet", action="store_false", help="Suppress output")
+        self._parser = ArgumentParser(description=description)
+        self._manager = SourceManager()
 
-    def add_argument(self, *args, **kwargs) -> None:
-        self.parser.add_argument(*args, **kwargs)
+        self.addArgument("source", help="Data set to interact with", metavar="SOURCE")
+        self.addArgument("-q", "--quiet", action="store_false", help="Suppress output during execution")
 
-    def parse_args(self, *args, **kwargs) -> tuple[list[BasicDB], list[Flag], argparse.Namespace]:
-        parsedArgs = self.parser.parse_args(*args, **kwargs)
+        self.addArgument("-p", "--reprepare", action="store_true", help=reprepareHelp)
+        self.addArgument("-o", "--overwrite", action="store_true", help=overwriteHelp)
 
-        sources = self.manager.requestDBs(self._extract(parsedArgs, "source"))
+    def addArgument(self, *args, **kwargs) -> None:
+        self._parser.add_argument(*args, **kwargs)
+
+    def parseArgs(self, *args, kwargsDict: bool = False, **kwargs) -> tuple[list[BasicDB], list[Flag], Namespace | dict]:
+        parsedArgs = self._parser.parse_args(*args, **kwargs)
+
+        sources = self._manager.requestDBs(self._extract(parsedArgs, "source"))
         if len(sources) >= self.sourceWarning:
             passed = self._warnSources(len(sources))
             if not passed:
@@ -28,22 +29,18 @@ class ArgParser:
 
         flagMap = {
             "quiet": Flag.VERBOSE,
-            "prepare": Flag.PREPARE_OVERWRITE,
-            "overwrite": Flag.OUTPUT_OVERWRITE,
-            "update": Flag.UPDATE
+            "reprepare": Flag.REPREPARE,
+            "overwrite": Flag.OVERWRITE
         }
 
         flags = [flag for key, flag in flagMap.items() if self._extract(parsedArgs, key)]
 
-        return sources, flags, parsedArgs
-    
-    def namespaceKwargs(self, namespace: argparse.Namespace) -> dict:
-        return vars(namespace)
+        return sources, flags, parsedArgs.__dict__ if kwargsDict else parsedArgs
 
-    def add_mutually_exclusive_group(self, *args, **kwargs) -> argparse._MutuallyExclusiveGroup:
-        return self.parser.add_mutually_exclusive_group(*args, **kwargs)
+    def addMutuallyExclusiveGroup(self, *args, **kwargs) -> _MutuallyExclusiveGroup:
+        return self._parser.add_mutually_exclusive_group(*args, **kwargs)
     
-    def _extract(self, namespace: argparse.Namespace, attribute: str) -> any:
+    def _extract(self, namespace: Namespace, attribute: str) -> any:
         attr = getattr(namespace, attribute)
         delattr(namespace, attribute)
         return attr

--- a/src/lib/data/database.py
+++ b/src/lib/data/database.py
@@ -19,7 +19,7 @@ class Retrieve(Enum):
     SCRIPT  = "script"
 
 class Flag(Enum):
-    VERBOSE   = "verbose"
+    VERBOSE   = "quiet" # Verbosity enabled by default, flag is used when silenced
     REPREPARE = "reprepare"
     OVERWRITE = "overwrite"
 

--- a/src/lib/systemManagers/baseManager.py
+++ b/src/lib/systemManagers/baseManager.py
@@ -20,11 +20,20 @@ class Metadata(Enum):
     CUSTOM = ""
 
 class Task:
+    def __init__(self):
+        self._runMetadata = {}
+
     def getOutputPath(self) -> Path:
         raise NotImplementedError
 
     def runTask(self) -> bool:
         raise NotImplementedError
+    
+    def setAdditionalMetadata(self, metadata: dict) -> None:
+        self._runMetadata = metadata
+
+    def getRunMetadata(self) -> dict:
+        return self._runMetadata
 
 class SystemManager:
     def __init__(self, baseDir: Path, dataDir: Path, stepKey: str, taskName: str):
@@ -77,6 +86,11 @@ class SystemManager:
                 Metadata.TASK_END: taskEndDate,
                 Metadata.TASK_DURATION: duration,
             }
+
+            # Task can set metadata on itself during run
+            extraMetadata = task.getRunMetadata()
+            if extraMetadata:
+                packet[Metadata.CUSTOM] = extraMetadata
 
             if success:
                 packet |= {

--- a/src/lib/systemManagers/conversion.py
+++ b/src/lib/systemManagers/conversion.py
@@ -20,6 +20,8 @@ class Conversion(Task):
         self.output = output
         self.augments = augments
 
+        super().__init__()
+
     def getOutputPath(self) -> Path:
         return self.output.filePath
 

--- a/src/lib/systemManagers/conversion.py
+++ b/src/lib/systemManagers/conversion.py
@@ -4,12 +4,107 @@ from lib.bigFileWriter import BigFileWriter
 from lib.processing.mapping import Map
 from lib.processing.stages import File, StackedFile
 from lib.processing.scripts import FunctionScript
-from lib.systemManagers.baseManager import SystemManager, Metadata
+from lib.systemManagers.baseManager import SystemManager, Task
 import logging
 import gc
-import time
-from datetime import datetime, date
+from datetime import date
 import lib.zipping as zp
+
+class Conversion(Task):
+    def __init__(self, prefix: str, datasetID: str, map: Map, inputFile: File, chunkSize: int, output: StackedFile, augments: list[FunctionScript]):
+        self.prefix = prefix
+        self.datasetID = datasetID
+        self.map = map
+        self.inputFile = inputFile
+        self.chunkSize = chunkSize
+        self.output = output
+        self.augments = augments
+
+    def getOutputPath(self) -> Path:
+        return self.output.filePath
+
+    def _processChunk(self, chunk: pd.DataFrame) -> pd.DataFrame | None:
+        df = self.map.applyTo(chunk, self.prefix) # Returns a multi-index dataframe
+        df = self._applyAugments(df)
+
+        if df is None:
+            return
+
+        datasetID = "dataset_id"
+        scientificName = "scientific_name"
+        canonicalName = "canonical_name"
+        entityID = "entity_id"
+
+        collection = "collection"
+
+        if scientificName not in df[collection].columns:
+            if canonicalName in df[collection].columns:
+                scientificName = canonicalName
+
+            else:
+                logging.error(f"Unable to generate '{entityID}' as dataset is missing field '{scientificName}' in event '{collection}'")
+                return
+        
+        df[(collection, datasetID)] = self.datasetID
+        df[(collection, entityID)] = df[(collection, datasetID)] + df[(collection, scientificName)]
+        return df
+
+    def runTask(self, overwrite: bool, verbose: bool) -> bool:
+        if self.output.filePath.exists() and not overwrite:
+            logging.info(f"{self.getOutputPath()} already exists, exiting...")
+            return True
+        
+        writers: dict[str, BigFileWriter] = {}
+        for event in self.map.events:
+            cleanedName = event.replace(" ", "_")
+            writers[event] = BigFileWriter(self.output.filePath / f"{cleanedName}.csv", f"{cleanedName}_chunks")
+
+        logging.info("Processing chunks for conversion")
+
+        totalRows = 0
+        chunks = self.inputFile.loadDataFrameIterator(self.chunkSize)
+        for idx, df in enumerate(chunks, start=1):
+            if verbose:
+                print(f"At chunk: {idx}", end='\r')
+
+            df = self._processChunk(df)
+            if df is None:
+                return False
+
+            for eventColumn in df.columns.levels[0]:
+                writers[eventColumn].writeDF(df[eventColumn])
+
+            totalRows += len(df)
+            del df
+            gc.collect()
+
+        totalUnmapped = 0
+        for writer in writers.values():
+            totalUnmapped += sum(1 for column in writer.globalColumns if column not in self.map.translation)
+            writer.oneFile()
+
+        self.setAdditionalMetadata(
+            {
+                "total columns": len(self.inputFile.getColumns()),
+                "unmapped columns": totalUnmapped,
+                "rows": totalRows
+            }
+        )
+
+        return True
+    
+    def _applyAugments(self, df: pd.DataFrame) -> pd.DataFrame | None:
+        for augment in self.augments:
+            success, df = augment.run(False, inputArgs=[df])
+
+            if not success:
+                return None
+
+            if not isinstance(df, pd.DataFrame):
+                logging.error(f"Augment '{augment.function}' does not output dataframe as required, instead output {type(df)}")
+                return None
+            
+        return df
 
 class ConversionManager(SystemManager):
     def __init__(self, baseDir: Path, dataDir: Path, mapDir: Path, datasetID: str, prefix: str, name: str):
@@ -20,9 +115,8 @@ class ConversionManager(SystemManager):
         self.prefix = prefix
         self.name = name
 
-        self.inputFile = None
         self.mapFile = mapDir / "map.json"
-        self.map = {}
+        self.conversion = []
 
     def _generateFileName(self, withTimestamp: bool) -> StackedFile:
         outputName = f"{self.name}{date.today().strftime('-%Y-%m-%d') if withTimestamp else ''}"
@@ -42,112 +136,32 @@ class ConversionManager(SystemManager):
         return None
 
     def prepare(self, file: File, properties: dict, forceRetrieve: bool) -> None:
-        self.inputFile = file
-
         mapID = properties.pop("mapID", -1)
         mapColumnName = properties.pop("mapColumnName", "")
-        self.map = self._getMap(mapID, mapColumnName, forceRetrieve)
+        map = self._getMap(mapID, mapColumnName, forceRetrieve)
+
+        if map is None:
+            logging.error(f"Unable to retrieve a map for {self.name}")
+            return
 
         timestamp = properties.pop("timestamp", True)
-        self.output = self._generateFileName(timestamp)
+        output = self._generateFileName(timestamp)
 
-        self.chunkSize = properties.pop("chunkSize", 1024)
-        self.augments = [FunctionScript(self.baseDir, augProperties) for augProperties in properties.pop("augment", [])]
+        chunkSize = properties.pop("chunkSize", 1024)
+        augments = [FunctionScript(self.baseDir, augProperties) for augProperties in properties.pop("augment", [])]
+
+        self.conversion.append(Conversion(self.prefix, self.datasetID, map, file, chunkSize, output, augments))
 
     def convert(self, overwrite: bool = False, verbose: bool = True) -> bool:
-        if self.inputFile is None:
+        if not self.conversion:
             logging.error("No file loaded for conversion, exiting...")
             return False
 
         if self.datasetID is None:
             logging.error("No datasetID provided which is required for conversion, exiting...")
             return False
-
-        if self.output.filePath.exists() and not overwrite:
-            logging.info(f"{self.output.filePath} already exists, exiting...")
-            return True
         
-        if self.map is None:
-            logging.error("No map found, exiting...")
-            return False
-        
-        writers: dict[str, BigFileWriter] = {}
-        for event in self.map.events:
-            cleanedName = event.replace(" ", "_")
-            writers[event] = BigFileWriter(self.output.filePath / f"{cleanedName}.csv", f"{cleanedName}_chunks")
-
-        logging.info("Processing chunks for conversion")
-        
-        totalRows = 0
-        startTime = time.perf_counter()
-
-        chunks = self.inputFile.loadDataFrameIterator(self.chunkSize)
-        for idx, df in enumerate(chunks, start=1):
-            if verbose:
-                print(f"At chunk: {idx}", end='\r')
-
-            df = self.map.applyTo(df, self.prefix) # Returns a multi-index dataframe
-            df = self.applyAugments(df)
-
-            if df is None:
-                return False
-
-            datasetID = "dataset_id"
-            scientificName = "scientific_name"
-            canonicalName = "canonical_name"
-            entityID = "entity_id"
-
-            collection = "collection"
-
-            if scientificName not in df[collection].columns:
-                if canonicalName in df[collection].columns:
-                    scientificName = canonicalName
-
-                else:
-                    logging.error(f"Unable to generate '{entityID}' as dataset is missing field '{scientificName}' in event '{collection}'")
-                    return False
-            
-            df[(collection, datasetID)] = self.datasetID
-            df[(collection, entityID)] = df[(collection, datasetID)] + df[(collection, scientificName)]
-
-            for eventColumn in df.columns.levels[0]:
-                writers[eventColumn].writeDF(df[eventColumn])
-
-            totalRows += len(df)
-            del df
-            gc.collect()
-
-        totalUnmapped = 0
-        for writer in writers.values():
-            totalUnmapped += sum(1 for column in writer.globalColumns if column not in self.map.translation)
-            writer.oneFile()
-
-        self.updateMetadata(0, {
-            Metadata.OUTPUT: self.output.filePath.name,
-            Metadata.SUCCESS: True,
-            Metadata.DURATION: time.perf_counter() - startTime,
-            Metadata.TIMESTAMP: datetime.now().isoformat(),
-            Metadata.CUSTOM: {
-                "columns": len(self.inputFile.getColumns()),
-                "unmappedColumns": totalUnmapped,
-                "rows": totalRows
-            }
-        })
-        
-        return True
-
-    def applyAugments(self, df: pd.DataFrame) -> pd.DataFrame | None:
-        for augment in self.augments:
-            success, df = augment.run(False, inputArgs=[df])
-
-            if not success:
-                return None
-
-            if not isinstance(df, pd.DataFrame):
-                logging.error(f"Augment '{augment.function}' does not output dataframe as required, instead output {type(df)}")
-                return None
-            
-        return df
+        return self.runTasks(self.conversion, overwrite, verbose)
     
     def package(self, compressLocation: Path) -> Path | None:
         outputFileName = self.getLastOutput()

--- a/src/lib/systemManagers/downloading.py
+++ b/src/lib/systemManagers/downloading.py
@@ -7,6 +7,8 @@ import lib.downloading as dl
 
 class _Download(Task):
     def __init__(self, filePath: Path, properties: dict):
+        super().__init__()
+        
         self.file = File(filePath, properties)
 
     def getOutputPath(self) -> Path:

--- a/src/lib/systemManagers/processing.py
+++ b/src/lib/systemManagers/processing.py
@@ -6,6 +6,8 @@ import logging
 
 class _Node(Task):
     def __init__(self, index: str, script: FileScript, parents: list['_Node']):
+        super().__init__()
+
         self.index = index
         self.script = script
         self.parents = parents

--- a/src/tools/convert.py
+++ b/src/tools/convert.py
@@ -2,10 +2,11 @@ from lib.data.argParser import ArgParser
 from lib.processing.stages import Step
 
 if __name__ == '__main__':
-    parser = ArgParser(description="Convert preDWC file to DWC")
-    parser.add_argument("-f", "--forceRetrieve", action="store_true", help="Force retrieve maps from google sheets")
+    parser = ArgParser(
+        description="Convert file to ARGA schema",
+        reprepareHelp="Force retrieval of map",
+    )
 
-    sources, flags, args = parser.parse_args()
-    kwargs = parser.namespaceKwargs(args)
+    sources, flags, kwargs = parser.parseArgs()
     for source in sources:
-        source.create(Step.CONVERSION, flags, **kwargs)
+        source.create(Step.CONVERSION, flags)

--- a/src/tools/download.py
+++ b/src/tools/download.py
@@ -2,9 +2,11 @@ from lib.data.argParser import ArgParser
 from lib.processing.stages import Step
 
 if __name__ == '__main__':
-    parser = ArgParser(description="Download source data")
+    parser = ArgParser(
+        description="Download source data",
+        reprepareHelp="Force retrieval of download information"
+    )
 
-    sources, flags, args = parser.parse_args()
-    kwargs = parser.namespaceKwargs(args)
+    sources, flags, kwargs = parser.parseArgs()
     for source in sources:
-        source.create(Step.DOWNLOAD, flags, **kwargs)
+        source.create(Step.DOWNLOAD, flags)

--- a/src/tools/package.py
+++ b/src/tools/package.py
@@ -4,7 +4,7 @@ from lib.processing.stages import Step
 if __name__ == '__main__':
     parser = ArgParser(description="Package converted data")
 
-    sources, flags, args = parser.parse_args()
+    sources, args, prepArgs, execArgs = parser.parseArgs()
     kwargs = parser.namespaceKwargs(args)
     for source in sources:
         source.package()

--- a/src/tools/process.py
+++ b/src/tools/process.py
@@ -4,7 +4,6 @@ from lib.processing.stages import Step
 if __name__ == '__main__':
     parser = ArgParser(description="Prepare for DwC conversion")
     
-    sources, flags, args = parser.parse_args()
-    kwargs = parser.namespaceKwargs(args)
+    sources, flags, kwargs = parser.parseArgs()
     for source in sources:
-        source.create(Step.PROCESSING, flags, **kwargs)
+        source.create(Step.PROCESSING, flags)

--- a/src/tools/purgeSource.py
+++ b/src/tools/purgeSource.py
@@ -4,11 +4,11 @@ import logging
 
 if __name__ == '__main__':
     parser = ArgParser(description="Clean up source to save space")
-    parser.add_argument("-r", "--raw", action="store_true", help="Clear raw/downloaded files too")
+    parser.addArgument("-r", "--raw", action="store_true", help="Clear raw/downloaded files too")
 
-    sources, _, _, args = parser.parse_args()
+    sources, flags, kwargs = parser.parseArgs()
     for source in sources:
-        dataDir = source.getBaseDir() / "data"
+        dataDir = source.baseDir / "data"
 
         for folder in dataDir.iterdir():
             if folder.is_file(): # Skip files that may be in dir

--- a/src/tools/sampleConversion.py
+++ b/src/tools/sampleConversion.py
@@ -6,15 +6,15 @@ import logging
 
 if __name__ == '__main__':
     parser = ArgParser(description="View portion of Converted file")
-    parser.add_argument("-e", "--entries", type=int, default=100, help="Amount of entries to view")
-    parser.add_argument("-t", "--tsv", action="store_true", help="Output file as TSV instead")
-    columnGroup = parser.add_mutually_exclusive_group()
+    parser.addArgument("-e", "--entries", type=int, default=100, help="Amount of entries to view")
+    parser.addArgument("-t", "--tsv", action="store_true", help="Output file as TSV instead")
+    columnGroup = parser.addMutuallyExclusiveGroup()
     columnGroup.add_argument("-m", "--mapped", action="store_true", help="Get only mapped fields")
     columnGroup.add_argument("-U", "--unmapped", action="store_true", help="Get only unmapped fields")
     
-    sources, flags, args = parser.parse_args()
-    suffix = ".tsv" if args.tsv else ".csv"
-    delim = "\t" if args.tsv else ","
+    sources, flags, kwargs = parser.parseArgs()
+    suffix = ".tsv" if kwargs.tsv else ".csv"
+    delim = "\t" if kwargs.tsv else ","
 
     for source in sources:
         source._prepare(Step.CONVERSION, flags)
@@ -26,14 +26,14 @@ if __name__ == '__main__':
             continue
 
         outputFolder = lastConversionFile.name
-        if args.mapped:
+        if kwargs.mapped:
             outputFolder += "_mapped"
-        elif args.unmapped:
+        elif kwargs.unmapped:
             outputFolder += "_unmapped"
         outputFolder += "_example"
 
         stackedFile = StackedFile(lastConversionFile)
-        df = next(stackedFile.loadDataFrameIterator(rows=args.entries))
+        df = next(stackedFile.loadDataFrameIterator(rows=kwargs.entries))
 
         folderPath = source.exampleDir / outputFolder
         folderPath.mkdir(exist_ok=True)
@@ -41,7 +41,7 @@ if __name__ == '__main__':
         dummpyMap = Map({})
 
         for event in df.columns.levels[0]:
-            if (args.mapped and event == dummpyMap._unmappedLabel) or (args.unmapped and event != dummpyMap._unmappedLabel):
+            if (kwargs.mapped and event == dummpyMap._unmappedLabel) or (kwargs.unmapped and event != dummpyMap._unmappedLabel):
                 continue
 
             fileName = f"{event}{suffix}"

--- a/src/tools/samplePreConversion.py
+++ b/src/tools/samplePreConversion.py
@@ -37,8 +37,8 @@ if __name__ == '__main__':
     parser.add_argument('-f', '--firstrow', type=int, default=0, help="First row offset for reading data")
     parser.add_argument('-r', '--rows', type=int, help="Maximum amount of rows to read from file")
 
-    sources, flags, args = parser.parse_args()
-    entryLimit = args.entries
+    sources, flags, kwargs = parser.parseArgs()
+    entryLimit = kwargs.entries
 
     for source in sources:
         outputDir = source.exampleDir
@@ -52,12 +52,12 @@ if __name__ == '__main__':
             print(f"File {stageFile.filePath} does not exist, please run all required downloading/processing.")
             continue
 
-        seed = args.seed if args.seed >= 0 else random.randrange(2**32 - 1) # Max value for pandas seed
+        seed = kwargs.seed if kwargs.seed >= 0 else random.randrange(2**32 - 1) # Max value for pandas seed
         random.seed(seed)
-        outputPath = outputDir / f"{'fields' if args.ignoreRecord else 'records'}_{args.chunksize}_{seed}.tsv"
+        outputPath = outputDir / f"{'fields' if kwargs.ignoreRecord else 'records'}_{kwargs.chunksize}_{seed}.tsv"
 
-        dfIterator = stageFile.loadDataFrameIterator(args.chunksize, args.firstrow, args.rows)
-        df = _collectFields(dfIterator, args.entries, seed) if args.ignoreRecord else _collectRecords(dfIterator, args.entries, seed)
+        dfIterator = stageFile.loadDataFrameIterator(kwargs.chunksize, kwargs.firstrow, kwargs.rows)
+        df = _collectFields(dfIterator, kwargs.entries, seed) if kwargs.ignoreRecord else _collectRecords(dfIterator, kwargs.entries, seed)
 
         df = dff.removeSpaces(df)
         df.index += 1 # Increment index so output is 1-indexed numbers

--- a/src/tools/update.py
+++ b/src/tools/update.py
@@ -5,10 +5,9 @@ if __name__ == '__main__':
     parser = ArgParser(description="Run update on data source")
     parser.add_argument("-f", "--force", action="store_true", help="Force update regardless of config")
     
-    sources, flags, args = parser.parse_args()
-    kwargs = parser.namespaceKwargs(args)
+    sources, flags, kwargs = parser.parseArgs()
     for source in sources:
-        if not source.checkUpdateReady() and not args.force:
+        if not source.checkUpdateReady() and not kwargs.force:
             logging.info(f"Data source '{source}' is not ready for update.")
             continue
 


### PR DESCRIPTION
- Updated return type in SystemManager getFileMetadata
- Updated BaseManager to have more metadata for last successful run
- Updated ConversionManager to use Tasks properly, to unify metadata
- Updated crawler to no longer say it's crawling if it does not intend to
- Updated many entry points to use new ArgParser functions
- Updated ArgParser functions to use stylings similar to rest of codebase
- Updated ArgParser to no longer use Update Flag
- No longer pass any kwargs into prepare and execute steps
- Added ability for tasks to create custom metadata while running
- Changed Verbose flag value to quiet due to always verbose
- Now use reprepare Flag to handle force retrieving of conversion maps