### PR TITLE
Download Import llib

### DIFF
--- a/src/lib/data/database.py
+++ b/src/lib/data/database.py
@@ -63,9 +63,12 @@ class BasicDB:
         username = sourceSecrets.username if sourceSecrets is not None else ""
         password = sourceSecrets.password if sourceSecrets is not None else ""
 
+        # Location Library
+        scriptImportLibs = {".llib": self.libDir}
+
         # System Managers
-        self.downloadManager = DownloadManager(self.dataDir, self.scriptsDir, self.databaseDir, username, password)
-        self.processingManager = ProcessingManager(self.dataDir, self.scriptsDir, self.databaseDir, self.libDir)
+        self.downloadManager = DownloadManager(self.dataDir, self.scriptsDir, self.databaseDir, scriptImportLibs, username, password)
+        self.processingManager = ProcessingManager(self.dataDir, self.scriptsDir, self.databaseDir, scriptImportLibs)
         self.conversionManager = ConversionManager(self.dataDir, self.scriptsDir, self.databaseDir, self.datasetID, self.location, self.name)
 
         # Config stages

--- a/src/lib/processing/scripts.py
+++ b/src/lib/processing/scripts.py
@@ -80,7 +80,7 @@ class FunctionScript:
     
     def run(self, verbose: bool, inputArgs: list = [], inputKwargs: dict = {}) -> tuple[bool, any]:
         try:
-            pathExtension = [str(path) for path in self.imports.values()]
+            pathExtension = [str(path.parent) for path in self.imports.values()]
             sys.path.extend(pathExtension)
             processFunction = self._importFunction(self.modulePath, self.function)
             sys.path = sys.path[:-len(pathExtension)]

--- a/src/lib/systemManagers/processing.py
+++ b/src/lib/systemManagers/processing.py
@@ -52,16 +52,15 @@ class _Root(_Node):
         return True
 
 class ProcessingManager(SystemManager):
-    def __init__(self, dataDir: Path, scriptDir: Path, metadataDir: Path, importDir: Path):
+    def __init__(self, dataDir: Path, scriptDir: Path, metadataDir: Path, scriptImports: dict[str, Path]):
         super().__init__(dataDir, scriptDir, metadataDir, "processing", "steps")
 
-        self.importDir = importDir
+        self.scriptImports = scriptImports
 
         self._rootNodes: list[_Node] = []
         self._scriptNodes: list[list[_Node]] = []
 
     def _createNode(self, step: dict, parents: list[_Node], depth: int) -> _Node | None:
-        # inputs = {FileSelect.INPUT: [self.getLatestNodeFile(depth)]} | {select: [node.getOutputFile() for node in nodes] for select, nodes in self.nodes.items()}
         fileInput = self._rootNodes[-1] if depth == 0 else self._scriptNodes[depth-1][-1]
         flatScriptNodes = [node for nodeList in self._scriptNodes for node in nodeList]
 
@@ -72,7 +71,7 @@ class ProcessingManager(SystemManager):
         }
         
         try:
-            script = FileScript(self.scriptDir, dict(step), self.workingDir, inputs, {".llib": self.importDir.parent})
+            script = FileScript(self.scriptDir, dict(step), self.workingDir, inputs, self.scriptImports)
         except AttributeError as e:
             logging.error(f"Invalid processing script configuration: {e}")
             return None


### PR DESCRIPTION
- Script downloads now properly handle .llib path in config
- Moved llib key/value pair to database object from ProcessingManager
- Updated scripts to now add parent path of import folder to system path so import can properly be selected by name