### PR TITLE
Processing Fixes

### DIFF
--- a/src/lib/data/database.py
+++ b/src/lib/data/database.py
@@ -91,10 +91,13 @@ class Database:
         _generate(historicFolders[historicFolderNum])
         return True
 
-    def _getFiles(self, step: Step) -> list[list[DataFile]]:
+    def _getFiles(self, step: Step, limitIdx: int = -1) -> list[list[DataFile]]:
         files = []
         
-        for stepMetadata in self._metadata.get(step.value, []):
+        for idx, stepMetadata in enumerate(self._metadata.get(step.value, [])):
+            if limitIdx >= 0 and idx < limitIdx: # Valid max position, and must be below the limit
+                break
+
             stepFiles = []
 
             for fileName in stepMetadata.get(tasks.Metadata.OUTPUTS.value):
@@ -131,7 +134,7 @@ class Database:
             elif retrieve == Retrieve.CRAWL:
                 task = tasks.CrawlRetrieve(self.workingDirs[Step.DOWNLOADING], taskConfig, self.locationName)
             elif retrieve == Retrieve.SCRIPT:
-                task = tasks.ScriptRunner(self.workingDirs[Step.DOWNLOADING], taskConfig, self.dirLookup, self._getFiles(Step.DOWNLOADING), [])
+                task = tasks.ScriptRunner(self.workingDirs[Step.DOWNLOADING], taskConfig, self.dirLookup, self._getFiles(Step.DOWNLOADING, idx), [])
             else:
                 raise Exception(f"Unknown retrieve type '{retrieveType}' specified for {self.name}") from AttributeError
             
@@ -146,7 +149,7 @@ class Database:
         processingConfig: list[dict] = self.config.get(Step.PROCESSING.value, [])
 
         for idx, processingStep in enumerate(processingConfig):
-            task = tasks.ScriptRunner(self.workingDirs[Step.PROCESSING], processingStep, self.dirLookup, self._getFiles(Step.DOWNLOADING), self._getFiles(Step.PROCESSING))
+            task = tasks.ScriptRunner(self.workingDirs[Step.PROCESSING], processingStep, self.dirLookup, self._getFiles(Step.DOWNLOADING), self._getFiles(Step.PROCESSING, idx))
 
             if not self._execute(Step.PROCESSING, idx, task, flags):
                 logging.error("Stopped evaluating processing tasks as previous task failed")
@@ -222,7 +225,7 @@ class Database:
                 return True
 
         if outputs:
-            backupDir.mkdir()
+            backupDir.mkdir(exist_ok=True)
 
         for file in outputs:
             file.backUp(backupDir)
@@ -261,8 +264,7 @@ class Database:
             parsedMetadata[key.value] = value
 
         taskMetadata: list[dict] = self._metadata.get(step.value, [])
-        if not isinstance(taskMetadata, list):
-            taskMetadata = []
+        taskMetadata = list(taskMetadata) if isinstance(taskMetadata, list) else [] # Get values if currently a list reference, or set to empty list if not a list
 
         if stepIndex < len(taskMetadata):
             taskMetadata[stepIndex] |= parsedMetadata

--- a/src/lib/json.py
+++ b/src/lib/json.py
@@ -9,7 +9,7 @@ class JsonSynchronizer:
         self._load()
 
     def __setitem__(self, key: str, value: any) -> None:
-        if key in self._data and self._data[key] == value:
+        if key in self._data and self._data.get(key) == value:
             return
         
         if isinstance(value, list):
@@ -19,7 +19,7 @@ class JsonSynchronizer:
         self._sync()
 
     def __getitem__(self, key: str) -> any:
-        return self._data[key]
+        return self._data.get(key, None)
     
     def __repr__(self) -> str:
         return str(self)

--- a/src/lib/processing/files.py
+++ b/src/lib/processing/files.py
@@ -44,6 +44,10 @@ class FileObject:
         
             backupPath.unlink()
         
+        if not self.path.exists():
+            logging.info("Unable to create backup as original file does not exist")
+            return
+
         self._backupPath = self.path.rename(backupPath)
 
     def restoreBackUp(self) -> None:


### PR DESCRIPTION
- Files will no longer attempt to make a backup if the file path does not exist
- JsonSynchronizer now uses get method over square bracket lookup to avoid potential errors
- Getting previous downloading and processing files in database is now limited to the current step you are executing
- Fixed an issue where database metadata was being updated due to a pass by reference error
- Fixed an issue with attempting to create a backup folder when it already existed